### PR TITLE
lmdb: converge duplicate things on backfill instead of skipping the clash

### DIFF
--- a/lmdb/api.py
+++ b/lmdb/api.py
@@ -402,16 +402,74 @@ def _find_thing(session: Session, thing: Thing) -> Optional[Thing]:
     return None
 
 
-def _apply_backfill(session: Session, existing: Thing, incoming: Thing) -> None:
-    """Fill NULL fields on `existing` from `incoming` (#147), guarding the unique indexes.
+# Loser columns carried onto the survivor on a merge when the survivor still lacks them. The
+# identity fields (url/native_id/extractor_key/backend) are deliberately excluded: they arrive
+# from the fresh pull via the caller's null_backfill *after* the loser (which holds the clashing
+# unique value) is deleted, so that write can never collide. `bucket` is excluded too (immutable,
+# never NULL [A10]); `machine_rating` is excluded (computed on read, the column is unread).
+_MERGE_CARRY_FIELDS = ("title", "channel", "thumbnail_url", "modified", "container",
+                       "human_rating", "best_oi", "last_success_dt", "last_failure_dt", "try_on")
 
-    Both partial-unique indexes are guarded: if backfilling `native_id` (thing_native) or
-    `url` (thing_url) would collide with a different existing row, that one field is skipped.
-    A clash means two rows describe one video (one created url-first, one native-key-first);
-    true cross-row merge is out of 4.0 scope, so we converge later (Phase 2) and just avoid
-    the unique violation here.
+
+def _merge_things(session: Session, survivor: Thing, loser: Thing) -> None:
+    """Converge a duplicate `loser` row into `survivor` — two rows that turned out to be one
+    real thing (incremental key discovery: one created url-first, one native-key-first, now a
+    pull carries both keys). Re-points `loser`'s rel/run FKs onto `survivor`, carries over the
+    survivor's still-NULL state/display fields + attrs from `loser`, then deletes `loser`.
+
+    `survivor` is the row the pull already matched (`_find_thing`: native key preferred, else
+    URL), so external refs already point at it. Identity unique fields are NOT copied here — the
+    caller sets them from the pull after this deletes the loser holding the clashing value.
+    """
+    # Re-point loser's edges onto survivor: drop the old rows, then re-insert remapped, OR-ing
+    # `channel` on any edge survivor already has (the monotonic upsert _ingest_pull uses) and
+    # dropping a self-loop the rename would create. Delete-then-insert (not UPDATE) so an edge
+    # survivor already shares can't trip the (parent, child) PK.
+    rels = session.exec(
+        select(Rel).where((Rel.parent == loser.id) | (Rel.child == loser.id))).all()
+    edges: dict[tuple[uuid.UUID, uuid.UUID], bool] = {}
+    for rel in rels:
+        parent = survivor.id if rel.parent == loser.id else rel.parent
+        child = survivor.id if rel.child == loser.id else rel.child
+        session.delete(rel)
+        if parent != child:
+            key = (parent, child)
+            edges[key] = edges.get(key, False) or rel.channel
+    session.flush()   # remove the loser's edges before re-inserting the remapped ones
+    if edges:
+        stmt = pg_insert(Rel).values(
+            [{"parent": p, "child": c, "channel": ch} for (p, c), ch in edges.items()])
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["parent", "child"],
+            set_={"channel": Rel.__table__.c.channel.op("OR")(stmt.excluded.channel)})
+        session.execute(stmt)
+    # Runs have no unique key on thing_id, so a plain re-point is enough.
+    session.execute(sa.update(Run).where(Run.thing_id == loser.id)
+                    .values(thing_id=survivor.id))
+    # Capture what the survivor should inherit, then delete the loser *before* writing it so the
+    # unique values it held (and the FKs) are gone first (SQLAlchemy orders deletes after updates
+    # within a flush, which would otherwise reintroduce the collision).
+    carry = {f: getattr(loser, f) for f in _MERGE_CARRY_FIELDS
+             if getattr(survivor, f) is None and getattr(loser, f) is not None}
+    loser_attrs = loser.attrs
+    session.delete(loser)
+    session.flush()
+    for field, value in carry.items():
+        setattr(survivor, field, value)
+    if loser_attrs:   # union attrs, survivor's own keys win
+        survivor.attrs = {**loser_attrs, **(survivor.attrs or {})}
+
+
+def _apply_backfill(session: Session, existing: Thing, incoming: Thing) -> None:
+    """Fill NULL fields on `existing` from `incoming` (#147), converging any duplicate row.
+
+    `null_backfill` proposes the still-NULL fields. If proposing `native_id` (thing_native) or
+    `url` (thing_url) would collide with a *different* row, that row is a duplicate of the same
+    real thing: merge it into `existing` (`_merge_things`) so the proposed value is free, then
+    apply it. Both partial-unique indexes flow through the one merge path.
     """
     fields = xform.null_backfill(existing, incoming)
+    clashes: dict[uuid.UUID, Thing] = {}
     if "native_id" in fields:
         ek = fields.get("extractor_key", existing.extractor_key)
         clash = session.exec(
@@ -420,13 +478,15 @@ def _apply_backfill(session: Session, existing: Thing, incoming: Thing) -> None:
                                 Thing.native_id == fields["native_id"],
                                 Thing.id != existing.id)).first()
         if clash is not None:
-            fields.pop("native_id")
+            clashes[clash.id] = clash
     if "url" in fields:
         clash = session.exec(
             select(Thing).where(Thing.url == fields["url"],
                                 Thing.id != existing.id)).first()
         if clash is not None:
-            fields.pop("url")
+            clashes[clash.id] = clash
+    for clash in clashes.values():
+        _merge_things(session, existing, clash)
     for key, value in fields.items():
         setattr(existing, key, value)
 

--- a/lmdb/test_api.py
+++ b/lmdb/test_api.py
@@ -766,17 +766,9 @@ def test_ingest_duplicate_entries(client):
     assert len(chan_parents) == 1
 
 
-def test_ingest_url_backfill_skips_on_clash(client):
-    # Two rows already describe one video: B holds the url (no native key), A was created
-    # native-key-first with url still NULL. A pull now carries BOTH keys, so the member matches
-    # A by native key and would backfill A.url to a value B already holds -> thing_url
-    # UniqueViolation (HTTP 500) pre-fix. The clashing url is skipped instead (cross-row merge
-    # is Phase 2); the non-colliding #147 backfill still applies.
-    clash_url = "http://example/v/clash"
-    b_id = _seed_thing(type="video", url=clash_url)                 # url, no native key
-    a_id = _seed_thing(type="video", extractor_key="youtube",       # native key, url NULL
-                       native_id="clashvid")
-
+def _url_clash_pull(client, clash_url):
+    """Run a pull whose single member carries both the native key of row A and the url of row B,
+    so the member matches A by native key but its url belongs to B. Returns (tid, response)."""
     url = "http://example/pl/clash"
     tid, rid = _claimed_run(client, url)
     up = models.UlChan(native_id="clashup", title="Clash Up", url="http://example/clashup")
@@ -787,20 +779,64 @@ def test_ingest_url_backfill_skips_on_clash(client):
             native_id="clashvid", title="Clash Video", url=clash_url,
             extractor_key="youtube", channel=up)],
     ).model_dump(mode="json")
+    return tid, client.post(f"/jobs/{rid}/result", json={"playlist": payload})
 
-    r = client.post(f"/jobs/{rid}/result", json={"playlist": payload})
+
+def test_ingest_url_clash_merges(client):
+    # Two rows already describe one video: B holds the url (no native key), A was created
+    # native-key-first with url still NULL. A pull carries BOTH keys, so the member matches A by
+    # native key while its url belongs to B -> pre-fix thing_url UniqueViolation (HTTP 500).
+    # Convergence: B is merged into the survivor A (rel/run FKs re-pointed, state carried), then
+    # A takes the url and B is gone.
+    clash_url = "http://example/v/clash"
+    # try_on=None on the seeded rows keeps them out of dispatch so _claimed_run claims the pull.
+    a_id = _seed_thing(type="video", extractor_key="youtube",       # native key, url NULL
+                       native_id="clashvid", try_on=None)
+    b_id = _seed_thing(type="video", url=clash_url, human_rating=2.0,  # url + rating, no native key
+                       try_on=None)
+    # B carries an edge + a run that must survive the merge by following B onto A.
+    par_id = _seed_thing(type="playlist", url="http://example/clashpar", try_on=None)
+    with _session() as s:
+        s.add(models.Rel(parent=uuid.UUID(par_id), child=uuid.UUID(b_id), channel=False))
+        s.add(models.Run(thing_id=uuid.UUID(b_id), success=True,
+                         starttime=models.naive_utcnow(), endtime=models.naive_utcnow()))
+        s.commit()
+
+    tid, r = _url_clash_pull(client, clash_url)
     assert r.status_code == 200            # pre-fix: 500 thing_url UniqueViolation
     assert r.json()["success"] is True
 
-    # A (matched by native key) keeps url NULL — the clashing backfill was skipped — but its
-    # other NULL fields are still filled from the pull (#147).
+    # Survivor A now holds the url (merged from B) and inherited B's rating; B is deleted.
     a = client.get(f"/things/{a_id}").json()
-    assert a["url"] is None
+    assert a["url"] == clash_url
+    assert a["native_id"] == "clashvid"
+    assert a["human_rating"] == 2.0        # carried from the loser (A had none)
     assert a["title"] == "Clash Video"
-    # B (the url holder) is untouched.
-    b = client.get(f"/things/{b_id}").json()
-    assert b["url"] == clash_url
-    assert b["native_id"] is None
+    assert client.get(f"/things/{b_id}").status_code == 404   # loser converged away
+
+    # B's edge + run followed it onto A.
+    a_related = client.get(f"/things/{a_id}/related").json()
+    assert any(e["direction"] == "parent" and e["thing"]["id"] == par_id for e in a_related)
+    assert client.get(f"/things/{a_id}/runs").json()          # A has B's run now (plus none of its own)
+
+
+def test_ingest_native_clash_merges(client):
+    # The native_id clash branch: the *container* is claimed by URL (native_id NULL), and its pull
+    # reveals a native_id that a stray row already holds. `_apply_backfill(container, ...)` would
+    # backfill that native_id and hit thing_native -> pre-fix UniqueViolation. The stray row is
+    # merged into the container (the survivor), which then takes the native key.
+    url = "http://example/pl/nclash"
+    stray = _seed_thing(type="playlist", extractor_key="youtube",   # native key, url NULL
+                        native_id="plnclash", try_on=None)          # not due -> claim the pull
+    tid, rid = _claimed_run(client, url)                            # container matched by URL
+    r = client.post(f"/jobs/{rid}/result",
+                    json={"playlist": _pl_payload(2, url=url, native="plnclash")})
+    assert r.status_code == 200            # pre-fix: 500 thing_native UniqueViolation
+    assert r.json()["success"] is True
+
+    container = client.get(f"/things/{tid}").json()
+    assert container["native_id"] == "plnclash"   # gained the stray row's native key
+    assert client.get(f"/things/{stray}").status_code == 404   # stray converged away
 
 
 def test_ingest_empty_playlist(client):


### PR DESCRIPTION
## Context

Follow-up to the Phase 1 hotfix on `master` (`lmdb: guard url backfill against the thing_url unique index`), which stopped a Stage-1 pull from 500-ing when a member's `url` backfill collided with a different existing row. That fix was deliberately conservative: it **skipped** the clashing field, which stopped the crash but left two duplicate rows describing one real thing in place forever.

This PR does the real convergence.

## Problem

Two rows can describe one video/playlist because keys are discovered incrementally — one row created URL-first (e.g. add-by-URL or a flat entry with no usable id), one created native-key-first (a flat entry with `id`+`ie_key` but no webpage URL). Neither key overlapped at creation, so they couldn't be unified. A later pull carrying **both** keys is the moment they can be reconciled — but backfilling the second key onto the matched row hits the other row's partial-unique index (`thing_url` or `thing_native`).

## Change

Replace the two skip-guards in `_apply_backfill` with a single merge path:

- New `_merge_things(session, survivor, loser)`: re-points the loser's `rel` edges (delete-then-`ON CONFLICT` re-insert, OR-ing `channel` — the same monotonic upsert `_ingest_pull` already uses; drops a self-loop) and its `run` rows (`thing_id` re-point) onto the survivor, carries over the survivor's still-NULL state/display fields + `attrs` from the loser, then deletes the loser. The loser is deleted **before** the survivor's unique value is written, so the freed index value can't re-collide (SQLAlchemy otherwise orders the DELETE after the UPDATE in one flush).
- `survivor` is the row the pull already matched (`_find_thing`: native key preferred, else URL) — deterministic — so external refs already point at it. Identity unique fields (`url`/`native_id`/`extractor_key`/`backend`) are **not** copied in the merge; they arrive from the fresh pull via the caller's `null_backfill` after the loser is gone.
- Both `thing_url` and `thing_native` clashes flow through the one merge path.

## Tests

- `test_ingest_url_clash_merges` — native-key row survives, URL row merged in; the loser's rel edge + run follow it onto the survivor, loser 404s. (Replaces the Phase 1 skip test.)
- `test_ingest_native_clash_merges` — the `thing_native` branch via a container claimed by URL whose pull reveals a native_id a stray row holds; stray merged into the container.

Full suite: **106 passed**.

## Notes for review

- This **deletes a row and re-points FKs** — data manipulation, not a schema change, so it stays within the 4.0 schema freeze. It does touch the V4 "deletion control" theme, flagged here intentionally.
- Survivor field reconciliation only copies a loser value where the survivor is NULL; a genuine conflict (both rows independently rated / both with `best_oi`) keeps the survivor's value. That case is vanishingly rare given how the duplicates arise, but worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
