### PR TITLE
OI scrubber: D/F media deletion + A-band replication (#111)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ OBJIDX_URL=http://127.0.0.1/ OBJIDX_AUTH=user LINKMEDDLE_PLAPI=http://localhost:
 # Download one URL directly through the yt-dlp pipeline
 OBJIDX_URL=http://127.0.0.1/ OBJIDX_AUTH=user python -m lmdb.run_bknd --oibucket bucket --no-playlist "https://example.com/video"
 
+# OI scrubber (#111, 4.1): tombstone D/F media in OI + enforce A-band copy counts in SO
+# Dry-run by default; --apply to act; --delete-only / --replicate-only for one branch
+OBJIDX_URL=http://127.0.0.1/ OBJIDX_AUTH=user OBJIDX_S3=http://127.0.0.1:29164/ python -m lmdb.scrub_oi
+
 # Tests
 pytest lmdb/test_api.py                       # all
 pytest lmdb/test_api.py::test_name            # single test
@@ -59,7 +63,7 @@ real file again — the V2-era `apiqueue/` copy is gone.)
 
 ## Environment variables
 
-`DATABASE_URL` (V4 defaults to `postgresql+psycopg:///lmdb`; PostgreSQL required), `LINKMEDDLE_PLAPI` (backend URL used by CLI/frontend/postprocessor), `OBJIDX_URL` + `OBJIDX_AUTH` (Object Index, required for uploads), `OBJIDX_BUCKET_DEFAULT` (lmfe), `CRUSTULA_URL` (cookie/auth microservice, used when a schedule sets `use_cookies`), `WORKER_MIN_FREE_BYTES` (job_runner free-space floor in bytes; default 32 GiB, `0` disables — the worker stops claiming when its cwd has less free space; shared with pervellam).
+`DATABASE_URL` (V4 defaults to `postgresql+psycopg:///lmdb`; PostgreSQL required), `LINKMEDDLE_PLAPI` (backend URL used by CLI/frontend/postprocessor), `OBJIDX_URL` + `OBJIDX_AUTH` (Object Index, required for uploads), `OBJIDX_S3` (simpler-objects locator base URL; scrubber replication branch only — same convention as the `obj_idx` CLI's `scrub`), `OBJIDX_BUCKET_DEFAULT` (lmfe), `CRUSTULA_URL` (cookie/auth microservice, used when a schedule sets `use_cookies`), `WORKER_MIN_FREE_BYTES` (job_runner free-space floor in bytes; default 32 GiB, `0` disables — the worker stops claiming when its cwd has less free space; shared with pervellam).
 
 ## V4 work
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,9 @@ OBJIDX_URL=http://127.0.0.1/ OBJIDX_AUTH=user LINKMEDDLE_PLAPI=http://localhost:
 # Download one URL directly through the yt-dlp pipeline
 OBJIDX_URL=http://127.0.0.1/ OBJIDX_AUTH=user python -m lmdb.run_bknd --oibucket bucket --no-playlist "https://example.com/video"
 
-# OI scrubber (#111, 4.1): tombstone D/F media in OI + enforce A-band copy counts in SO
-# Dry-run by default; --apply to act; --delete-only / --replicate-only for one branch
+# OI scrubber (#111, 4.1): delete D/F media (OI record + SO bytes), replicate A-band to
+# 2 copies, reduce below-B things to 1 copy (needs obj_idx >= 0.3.8, simpler-objects >= 0.6.0)
+# Dry-run by default; --apply to act; --delete-only / --replicate-only / --reduce-only for one branch
 OBJIDX_URL=http://127.0.0.1/ OBJIDX_AUTH=user OBJIDX_S3=http://127.0.0.1:29164/ python -m lmdb.scrub_oi
 
 # Tests
@@ -63,7 +64,7 @@ real file again — the V2-era `apiqueue/` copy is gone.)
 
 ## Environment variables
 
-`DATABASE_URL` (V4 defaults to `postgresql+psycopg:///lmdb`; PostgreSQL required), `LINKMEDDLE_PLAPI` (backend URL used by CLI/frontend/postprocessor), `OBJIDX_URL` + `OBJIDX_AUTH` (Object Index, required for uploads), `OBJIDX_S3` (simpler-objects locator base URL; scrubber replication branch only — same convention as the `obj_idx` CLI's `scrub`), `OBJIDX_BUCKET_DEFAULT` (lmfe), `CRUSTULA_URL` (cookie/auth microservice, used when a schedule sets `use_cookies`), `WORKER_MIN_FREE_BYTES` (job_runner free-space floor in bytes; default 32 GiB, `0` disables — the worker stops claiming when its cwd has less free space; shared with pervellam).
+`DATABASE_URL` (V4 defaults to `postgresql+psycopg:///lmdb`; PostgreSQL required), `LINKMEDDLE_PLAPI` (backend URL used by CLI/frontend/postprocessor), `OBJIDX_URL` + `OBJIDX_AUTH` (Object Index, required for uploads), `OBJIDX_S3` (simpler-objects locator base URL; all scrubber branches — same convention as the `obj_idx` CLI's `scrub`), `OBJIDX_BUCKET_DEFAULT` (lmfe), `CRUSTULA_URL` (cookie/auth microservice, used when a schedule sets `use_cookies`), `WORKER_MIN_FREE_BYTES` (job_runner free-space floor in bytes; default 32 GiB, `0` disables — the worker stops claiming when its cwd has less free space; shared with pervellam).
 
 ## V4 work
 

--- a/lmdb/scrub_oi.py
+++ b/lmdb/scrub_oi.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""V4 OI scrubber (#111): reconcile LM ratings against OI/SO media holdings.
+
+The 4.1 home of actual media deletion + replication (LM-V4-DESIGN.md Appendix A; 4.0
+records ratings but touches nothing):
+
+- deletion: a *human*-rated D/F thing with acquired media gets its OI object tombstoned
+  (PUT deleted=True). OI currently refuses to delete a *completed* object (objectindex#23),
+  so the attempt is verified and reported as pending until that lands -- rerunning
+  converges once it does. `best_oi` needs no repoint: it is the OI *file* UUID, whose
+  object simply becomes the tombstone. Byte removal in simpler-objects (no DELETE verb
+  yet) is likewise pending, and the F-only metadata purge is a separate 4.x feature.
+- replication: a thing assessing in the A band (effective rating >= +1.5) must hold
+  A_COPIES copies in simpler-objects; under-replicated objects are copied to additional
+  object servers straight through the locator (simpler_objects.async_replicate machinery).
+  Copy-count *reduction* (B/C tolerate 1 copy) needs an SO DELETE and stays out of scope.
+
+The scrubber never writes the LM database. Dry-run by default; pass --apply to act.
+Exits nonzero iff anomalies were found (pending deletions are not anomalies).
+Env: DATABASE_URL, OBJIDX_URL, OBJIDX_AUTH, and OBJIDX_S3 (locator; replication only).
+"""
+
+import argparse
+import os
+import random
+import httpx
+import requests
+from sqlmodel import Session, create_engine, select
+from obj_idx import client as oic
+from obj_idx.cli import get_s3_base
+from simpler_objects.async_replicate import find_space, replicate_object
+from . import xform
+from .api import _effective_rating_expr
+from .models import Thing
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+psycopg:///lmdb")
+
+# Copy policy (LM-V4-DESIGN.md §2.4): A = 2 copies. B/C tolerate their acquired single
+# copy, D/F want 0 (the deletion branch), so the A floor is the only count enforced here.
+A_COPIES = 2
+
+
+class Tally:
+    """Outcome counters for one scrub branch; `anomalies` drive the nonzero exit."""
+
+    def __init__(self):
+        self.checked = 0
+        self.ok = 0        # already converged (tombstoned / enough copies)
+        self.acted = 0     # deletions/copies applied (or dry-run "would")
+        self.pending = 0   # blocked on OI/SO capability (objectindex#23); not an anomaly
+        self.anomalies = 0
+
+    def anomaly(self, thing: Thing, msg: str) -> None:
+        self.anomalies += 1
+        print(f"ANOMALY thing {thing.id} ({thing.extractor_key} {thing.native_id}): {msg}")
+
+
+def deletion_candidates(session: Session) -> list[Thing]:
+    """Things whose media the scrubber should drop: acquired + human-rated D/F.
+
+    Human rating only (§2.4/Appendix A): a machine rating never triggers deletion.
+    """
+    return session.exec(select(Thing).where(
+        Thing.human_rating < xform.BAND_FLOOR["C"],
+        Thing.best_oi != None)).all()  # noqa: E711
+
+
+def replication_candidates(session: Session) -> list[Thing]:
+    """Things owed the A-band copy count: acquired + effective rating in the A band."""
+    return session.exec(select(Thing).where(
+        _effective_rating_expr(0.0) >= xform.BAND_FLOOR["A"],
+        Thing.best_oi != None)).all()  # noqa: E711
+
+
+def _fetch_object(objidx, thing: Thing, tally: Tally):
+    """The full OI object dict behind thing.best_oi (an OI *file* UUID), or None (anomaly)."""
+    try:
+        oif = objidx.get_file(thing.best_oi)
+    except requests.HTTPError as exc:
+        tally.anomaly(thing, f"best_oi {thing.best_oi} not fetchable from OI: {exc}")
+        return None
+    if not oif.object:
+        tally.anomaly(thing, f"OI file {thing.best_oi} has no object")
+        return None
+    return oif.object
+
+
+def _delete_media(objidx, obj: dict) -> bool:
+    """Tombstone a media object in OI; True iff OI honored it.
+
+    Today OI silently refuses to delete a *completed* object (returns it unchanged;
+    objectindex#23), so the caller treats False as pending, not failure. This is the one
+    seam to update if #23 ships a different verb (e.g. DELETE /object/{uuid}/data) --
+    removing the bytes in simpler-objects (which has no DELETE) belongs behind it too.
+    """
+    updated = objidx.put_object(obj["uuid"], {"deleted": True})
+    return bool(updated.get("deleted"))
+
+
+def scrub_deletions(things: list[Thing], objidx, apply: bool) -> Tally:
+    """Tombstone the OI media of human-D/F things (LM DB untouched; see module doc)."""
+    tally = Tally()
+    mode = "APPLY" if apply else "DRY "
+    for thing in things:
+        tally.checked += 1
+        obj = _fetch_object(objidx, thing, tally)
+        if obj is None:
+            continue
+        if obj["deleted"]:
+            tally.ok += 1  # already a tombstone; converged
+            continue
+        print(f"{mode} thing {thing.id} ({thing.extractor_key} {thing.native_id}) "
+              f"rated {thing.human_rating:+.0f}: delete object {obj['uuid']}")
+        if not apply:
+            tally.acted += 1
+        elif _delete_media(objidx, obj):
+            tally.acted += 1
+        else:
+            tally.pending += 1
+            print(f"        object {obj['uuid']} is completed; OI cannot tombstone it yet "
+                  f"(objectindex#23) -- will converge on a future scrub")
+    verb = "deleted" if apply else "would delete"
+    print(f"Deletion: checked {tally.checked}, tombstoned already {tally.ok}, "
+          f"{verb} {tally.acted}, pending {tally.pending}, anomalies {tally.anomalies}")
+    return tally
+
+
+def _bucket_listing(locator: str, bucket: str) -> dict:
+    """Per-key {size, checksum, directory, locations, error} from the SO locator.
+
+    (async_replicate.get_bucket_contents drops `locations`, which is the point here.)
+    """
+    res = httpx.get(locator + bucket + "/", timeout=32)
+    res.raise_for_status()
+    return res.json()["objects"]
+
+
+def scrub_replication(things: list[Thing], objidx, locator: str, apply: bool) -> Tally:
+    """Bring every A-band thing's object up to A_COPIES copies in simpler-objects."""
+    tally = Tally()
+    mode = "APPLY" if apply else "DRY "
+    listings: dict[str, dict | None] = {}
+    for thing in things:
+        tally.checked += 1
+        obj = _fetch_object(objidx, thing, tally)
+        if obj is None:
+            continue
+        if obj["deleted"] or not obj["completed"]:
+            state = "a tombstone" if obj["deleted"] else "incomplete"
+            tally.anomaly(thing, f"A-band but OI object {obj['uuid']} is {state} "
+                          "(re-acquire is the rating-change path's job, not the scrubber's)")
+            continue
+        bucket, key = obj["bucket"], obj["key"]
+        if bucket not in listings:
+            try:
+                listings[bucket] = _bucket_listing(locator, bucket)
+            except httpx.HTTPError as exc:
+                print(f"WARN locator listing for bucket {bucket} unavailable: {exc}")
+                listings[bucket] = None
+        listing = listings[bucket]
+        if listing is None:
+            tally.anomaly(thing, f"locator listing for bucket {bucket} unavailable")
+            continue
+        entry = listing.get(key)
+        if not entry or not entry.get("locations"):
+            tally.anomaly(thing, f"media {bucket}/{key} has no copies in simpler-objects (lost?)")
+            continue
+        if entry.get("error"):
+            # A copy may sit on an unreachable/sleeping server; replicating now could
+            # produce an extra copy (simpler-objects#76), so just flag it.
+            tally.anomaly(thing, f"{bucket}/{key}: locator reports an error; skipping")
+            continue
+        locations = entry["locations"]
+        if len(locations) >= A_COPIES:
+            tally.ok += 1
+            continue
+        needed = A_COPIES - len(locations)
+        print(f"{mode} thing {thing.id} ({thing.extractor_key} {thing.native_id}): "
+              f"{bucket}/{key} has {len(locations)} of {A_COPIES} copies")
+        if not apply:
+            tally.acted += 1
+            continue
+        targets = find_space(locator, bucket, obj["obj_size"], locations, needed)
+        if len(targets) < needed:
+            tally.anomaly(thing, f"no server with space for {needed} more copy(ies) "
+                          f"of {bucket}/{key}")
+            if not targets:
+                continue
+        try:
+            for target in targets:
+                src = random.choice(locations) + f"{bucket}/{key}"
+                dst = target + f"{bucket}/{key}"
+                print(f"        {src} => {dst}")
+                replicate_object(src, dst)
+            tally.acted += 1
+        except (httpx.HTTPError, AssertionError) as exc:
+            tally.anomaly(thing, f"replication of {bucket}/{key} failed: {exc}")
+    verb = "replicated" if apply else "would replicate"
+    print(f"Replication: checked {tally.checked}, at copy count {tally.ok}, "
+          f"{verb} {tally.acted}, anomalies {tally.anomalies}")
+    return tally
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--apply", action="store_true",
+                        help="act on findings (default: dry-run report only)")
+    branch = parser.add_mutually_exclusive_group()
+    branch.add_argument("--delete-only", action="store_true",
+                        help="only the D/F media-deletion branch")
+    branch.add_argument("--replicate-only", action="store_true",
+                        help="only the A-band replication branch")
+    parser.add_argument("--s3", help="simpler-objects locator base URL (default: $OBJIDX_S3)")
+    args = parser.parse_args()
+    do_delete = not args.replicate_only
+    do_replicate = not args.delete_only
+
+    objidx = oic.get_obj_idx_env()
+    locator = get_s3_base(args.s3) if do_replicate else None
+    engine = create_engine(DATABASE_URL, echo=False)
+    anomalies = 0
+    with Session(engine) as session:
+        if do_delete:
+            anomalies += scrub_deletions(deletion_candidates(session), objidx,
+                                         args.apply).anomalies
+        if do_replicate:
+            anomalies += scrub_replication(replication_candidates(session), objidx,
+                                           locator, args.apply).anomalies
+    return 1 if anomalies else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lmdb/scrub_oi.py
+++ b/lmdb/scrub_oi.py
@@ -2,22 +2,28 @@
 """V4 OI scrubber (#111): reconcile LM ratings against OI/SO media holdings.
 
 The 4.1 home of actual media deletion + replication (LM-V4-DESIGN.md Appendix A; 4.0
-records ratings but touches nothing):
+records ratings but touches nothing). Copy policy by effective rating band (§2.4):
+A holds a floor of A_COPIES, B is left alone, C and below (including unrated and
+machine-D/F) hold a ceiling of one copy, and human-D/F media is deleted outright.
 
-- deletion: a *human*-rated D/F thing with acquired media gets its OI object tombstoned
-  (PUT deleted=True). OI currently refuses to delete a *completed* object (objectindex#23),
-  so the attempt is verified and reported as pending until that lands -- rerunning
-  converges once it does. `best_oi` needs no repoint: it is the OI *file* UUID, whose
-  object simply becomes the tombstone. Byte removal in simpler-objects (no DELETE verb
-  yet) is likewise pending, and the F-only metadata purge is a separate 4.x feature.
+- deletion: a *human*-rated D/F thing with acquired media has its bytes removed from
+  simpler-objects and its OI record marked completed+deleted (obj_idx
+  client.delete_object_data: locator fan-out DELETE until every copy is confirmed gone,
+  then the combined PUT). `best_oi` needs no repoint: it is the OI *file* UUID, whose
+  object simply becomes the tombstone. Needs obj_idx >= 0.3.8 (objectindex#23) and
+  simpler-objects >= 0.6.0. The F-only metadata purge is a separate 4.x feature.
 - replication: a thing assessing in the A band (effective rating >= +1.5) must hold
   A_COPIES copies in simpler-objects; under-replicated objects are copied to additional
   object servers straight through the locator (simpler_objects.async_replicate machinery).
-  Copy-count *reduction* (B/C tolerate 1 copy) needs an SO DELETE and stays out of scope.
+  Extra A copies are never trimmed.
+- reduction: a thing assessing below the B band (and not human-D/F, which deletes above)
+  tolerates a single copy; excess copies are DELETEd directly on their object server --
+  the one with the most used bytes overall goes first. Each such delete leaves SO's
+  write-once checksum tombstone on that server (the key can never be re-placed there).
 
 The scrubber never writes the LM database. Dry-run by default; pass --apply to act.
-Exits nonzero iff anomalies were found (pending deletions are not anomalies).
-Env: DATABASE_URL, OBJIDX_URL, OBJIDX_AUTH, and OBJIDX_S3 (locator; replication only).
+Exits nonzero iff anomalies were found (pending = store busy, not an anomaly).
+Env: DATABASE_URL, OBJIDX_URL, OBJIDX_AUTH, and OBJIDX_S3 (locator; all branches).
 """
 
 import argparse
@@ -25,18 +31,19 @@ import os
 import random
 import httpx
 import requests
-from sqlmodel import Session, create_engine, select
+from sqlmodel import Session, create_engine, or_, select
 from obj_idx import client as oic
 from obj_idx.cli import get_s3_base
-from simpler_objects.async_replicate import find_space, replicate_object
+from simpler_objects import auth
+from simpler_objects.async_replicate import find_space, replicate_object, signed_suffix
 from . import xform
 from .api import _effective_rating_expr
 from .models import Thing
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+psycopg:///lmdb")
 
-# Copy policy (LM-V4-DESIGN.md §2.4): A = 2 copies. B/C tolerate their acquired single
-# copy, D/F want 0 (the deletion branch), so the A floor is the only count enforced here.
+# Copy policy (LM-V4-DESIGN.md §2.4): A = 2 copies (floor, replication branch), B keeps
+# whatever it has, C and below = 1 (ceiling, reduction branch), human-D/F = 0 (deletion).
 A_COPIES = 2
 
 
@@ -45,9 +52,9 @@ class Tally:
 
     def __init__(self):
         self.checked = 0
-        self.ok = 0        # already converged (tombstoned / enough copies)
+        self.ok = 0        # already converged (tombstoned / at copy count)
         self.acted = 0     # deletions/copies applied (or dry-run "would")
-        self.pending = 0   # blocked on OI/SO capability (objectindex#23); not an anomaly
+        self.pending = 0   # store busy/unreachable/read-only; not an anomaly
         self.anomalies = 0
 
     def anomaly(self, thing: Thing, msg: str) -> None:
@@ -72,6 +79,19 @@ def replication_candidates(session: Session) -> list[Thing]:
         Thing.best_oi != None)).all()  # noqa: E711
 
 
+def reduction_candidates(session: Session) -> list[Thing]:
+    """Things owed the one-copy ceiling: acquired + effective below B + not human-D/F.
+
+    B tolerates whatever it holds; human-D/F is the deletion branch's cohort. Unrated
+    (effective defaults to 0) and machine-D/F things assess at/below C and shrink to one.
+    """
+    return session.exec(select(Thing).where(
+        _effective_rating_expr(0.0) < xform.BAND_FLOOR["B"],
+        or_(Thing.human_rating == None,  # noqa: E711
+            Thing.human_rating >= xform.BAND_FLOOR["C"]),
+        Thing.best_oi != None)).all()  # noqa: E711
+
+
 def _fetch_object(objidx, thing: Thing, tally: Tally):
     """The full OI object dict behind thing.best_oi (an OI *file* UUID), or None (anomaly)."""
     try:
@@ -85,20 +105,21 @@ def _fetch_object(objidx, thing: Thing, tally: Tally):
     return oif.object
 
 
-def _delete_media(objidx, obj: dict) -> bool:
-    """Tombstone a media object in OI; True iff OI honored it.
+def _delete_media(objidx, obj: dict, locator: str) -> bool:
+    """Delete a media object's bytes and mark its OI record; True iff confirmed.
 
-    Today OI silently refuses to delete a *completed* object (returns it unchanged;
-    objectindex#23), so the caller treats False as pending, not failure. This is the one
-    seam to update if #23 ships a different verb (e.g. DELETE /object/{uuid}/data) --
-    removing the bytes in simpler-objects (which has no DELETE) belongs behind it too.
+    delete_object_data DELETEs on the SO locator (every copy must go, so the fan-out
+    verb, not a per-server one) until the store confirms 204/404, then marks the record
+    completed+deleted -- the durable tombstone best_oi points at. False means the retry
+    budget ran out with a copy possibly surviving (server busy/unreachable); the record
+    is left unmarked and rerunning converges. Raises ValueError for a never-completed
+    object and requests exceptions otherwise (e.g. missing `delete` RBAC).
     """
-    updated = objidx.put_object(obj["uuid"], {"deleted": True})
-    return bool(updated.get("deleted"))
+    return oic.delete_object_data(objidx, obj["uuid"], locator)
 
 
-def scrub_deletions(things: list[Thing], objidx, apply: bool) -> Tally:
-    """Tombstone the OI media of human-D/F things (LM DB untouched; see module doc)."""
+def scrub_deletions(things: list[Thing], objidx, locator: str, apply: bool) -> Tally:
+    """Delete the OI/SO media of human-D/F things (LM DB untouched; see module doc)."""
     tally = Tally()
     mode = "APPLY" if apply else "DRY "
     for thing in things:
@@ -113,12 +134,21 @@ def scrub_deletions(things: list[Thing], objidx, apply: bool) -> Tally:
               f"rated {thing.human_rating:+.0f}: delete object {obj['uuid']}")
         if not apply:
             tally.acted += 1
-        elif _delete_media(objidx, obj):
+            continue
+        try:
+            done = _delete_media(objidx, obj, locator)
+        except ValueError as exc:
+            tally.anomaly(thing, f"object {obj['uuid']} not deletable: {exc}")
+            continue
+        except requests.RequestException as exc:
+            tally.anomaly(thing, f"deletion of object {obj['uuid']} failed: {exc}")
+            continue
+        if done:
             tally.acted += 1
         else:
             tally.pending += 1
-            print(f"        object {obj['uuid']} is completed; OI cannot tombstone it yet "
-                  f"(objectindex#23) -- will converge on a future scrub")
+            print(f"        store did not confirm all copies of {obj['uuid']} gone "
+                  f"(a server busy/unreachable) -- will converge on a future scrub")
     verb = "deleted" if apply else "would delete"
     print(f"Deletion: checked {tally.checked}, tombstoned already {tally.ok}, "
           f"{verb} {tally.acted}, pending {tally.pending}, anomalies {tally.anomalies}")
@@ -133,6 +163,37 @@ def _bucket_listing(locator: str, bucket: str) -> dict:
     res = httpx.get(locator + bucket + "/", timeout=32)
     res.raise_for_status()
     return res.json()["objects"]
+
+
+def _copy_locations(thing: Thing, obj: dict, locator: str, listings: dict,
+                    tally: Tally) -> list | None:
+    """Current SO copy locations of obj, or None after recording an anomaly.
+
+    Shared by the replication and reduction branches: resolves (and caches, in
+    `listings`) the bucket listing and validates the key's entry -- lost media and
+    locator failures are anomalies, as is a per-key `error` flag, since a copy may sit
+    on an unreachable/sleeping server and acting now could produce an extra copy
+    (simpler-objects#76) or delete a survivor's twin.
+    """
+    bucket, key = obj["bucket"], obj["key"]
+    if bucket not in listings:
+        try:
+            listings[bucket] = _bucket_listing(locator, bucket)
+        except httpx.HTTPError as exc:
+            print(f"WARN locator listing for bucket {bucket} unavailable: {exc}")
+            listings[bucket] = None
+    listing = listings[bucket]
+    if listing is None:
+        tally.anomaly(thing, f"locator listing for bucket {bucket} unavailable")
+        return None
+    entry = listing.get(key)
+    if not entry or not entry.get("locations"):
+        tally.anomaly(thing, f"media {bucket}/{key} has no copies in simpler-objects (lost?)")
+        return None
+    if entry.get("error"):
+        tally.anomaly(thing, f"{bucket}/{key}: locator reports an error; skipping")
+        return None
+    return entry["locations"]
 
 
 def scrub_replication(things: list[Thing], objidx, locator: str, apply: bool) -> Tally:
@@ -150,31 +211,14 @@ def scrub_replication(things: list[Thing], objidx, locator: str, apply: bool) ->
             tally.anomaly(thing, f"A-band but OI object {obj['uuid']} is {state} "
                           "(re-acquire is the rating-change path's job, not the scrubber's)")
             continue
-        bucket, key = obj["bucket"], obj["key"]
-        if bucket not in listings:
-            try:
-                listings[bucket] = _bucket_listing(locator, bucket)
-            except httpx.HTTPError as exc:
-                print(f"WARN locator listing for bucket {bucket} unavailable: {exc}")
-                listings[bucket] = None
-        listing = listings[bucket]
-        if listing is None:
-            tally.anomaly(thing, f"locator listing for bucket {bucket} unavailable")
+        locations = _copy_locations(thing, obj, locator, listings, tally)
+        if locations is None:
             continue
-        entry = listing.get(key)
-        if not entry or not entry.get("locations"):
-            tally.anomaly(thing, f"media {bucket}/{key} has no copies in simpler-objects (lost?)")
-            continue
-        if entry.get("error"):
-            # A copy may sit on an unreachable/sleeping server; replicating now could
-            # produce an extra copy (simpler-objects#76), so just flag it.
-            tally.anomaly(thing, f"{bucket}/{key}: locator reports an error; skipping")
-            continue
-        locations = entry["locations"]
         if len(locations) >= A_COPIES:
             tally.ok += 1
             continue
         needed = A_COPIES - len(locations)
+        bucket, key = obj["bucket"], obj["key"]
         print(f"{mode} thing {thing.id} ({thing.extractor_key} {thing.native_id}): "
               f"{bucket}/{key} has {len(locations)} of {A_COPIES} copies")
         if not apply:
@@ -201,6 +245,107 @@ def scrub_replication(things: list[Thing], objidx, locator: str, apply: bool) ->
     return tally
 
 
+def _server_used_bytes(locator: str) -> dict:
+    """Per-object-server quota-used-bytes from the locator health endpoint.
+
+    An unreachable server reports 0 (the locator's own fallback), sorting it last --
+    which also means its copy is never the deletion victim while it cannot answer.
+    """
+    res = httpx.get(locator + "health", timeout=8)
+    res.raise_for_status()
+    return {server: stats.get("quota-used-bytes", 0)
+            for server, stats in res.json()["servers"].items()}
+
+
+def _delete_copy(server: str, bucket: str, key: str) -> int:
+    """DELETE one copy directly on an object server; returns the HTTP status.
+
+    The locator's DELETE is deliberately not used here: it fans out to every server
+    (every replica must go), while reduction removes exactly one chosen copy. Signed
+    like async_replicate's other direct object-server requests (CLUSTER_SECRET).
+    """
+    url = server + f"{bucket}/{key}" + signed_suffix(auth.OP_DELETE, bucket, key)
+    return httpx.delete(url, timeout=32).status_code
+
+
+def scrub_reduction(things: list[Thing], objidx, locator: str, apply: bool) -> Tally:
+    """Trim below-B things back to a single simpler-objects copy (the C ceiling).
+
+    The victim is the copy on the object server with the most used bytes overall
+    (locator health); a mid-upload (503) or read-only (405) server just shifts the
+    delete to the next-fullest copy. At most len(locations)-1 deletes are ever issued,
+    so one copy always survives. Each delete leaves SO's write-once checksum tombstone
+    on that server, permanently blocking the key from returning there.
+    """
+    tally = Tally()
+    mode = "APPLY" if apply else "DRY "
+    listings: dict[str, dict | None] = {}
+    used: dict | None = None  # one health fetch per run, first time a trim is due
+    for thing in things:
+        tally.checked += 1
+        obj = _fetch_object(objidx, thing, tally)
+        if obj is None:
+            continue
+        if obj["deleted"]:
+            tally.ok += 1  # nothing held; re-acquire is the rating-change path's job
+            continue
+        if not obj["completed"]:
+            tally.anomaly(thing, f"OI object {obj['uuid']} is incomplete")
+            continue
+        locations = _copy_locations(thing, obj, locator, listings, tally)
+        if locations is None:
+            continue
+        if len(locations) <= 1:
+            tally.ok += 1
+            continue
+        excess = len(locations) - 1
+        bucket, key = obj["bucket"], obj["key"]
+        print(f"{mode} thing {thing.id} ({thing.extractor_key} {thing.native_id}): "
+              f"{bucket}/{key} has {len(locations)} copies, ceiling 1")
+        if not apply:
+            tally.acted += 1
+            continue
+        if used is None:
+            try:
+                used = _server_used_bytes(locator)
+            except httpx.HTTPError as exc:
+                tally.anomaly(thing, f"locator health unavailable: {exc}")
+                continue
+        removed = 0
+        failed = False
+        for server in sorted(locations, key=lambda s: used.get(s, 0), reverse=True):
+            if removed >= excess:
+                break
+            try:
+                status = _delete_copy(server, bucket, key)
+            except httpx.HTTPError as exc:
+                tally.anomaly(thing, f"delete of {bucket}/{key} on {server} failed: {exc}")
+                failed = True
+                break
+            if status in (204, 404):  # 404: listing was stale, copy already gone
+                print(f"        removed {server}{bucket}/{key}")
+                removed += 1
+            elif status in (503, 405):
+                # mid-upload or read-only: leave this copy, try the next-fullest
+                print(f"        {server} busy/read-only (HTTP {status}); trying next copy")
+            else:
+                tally.anomaly(thing, f"delete of {bucket}/{key} on {server}: HTTP {status}")
+                failed = True
+                break
+        if failed:
+            continue
+        if removed >= excess:
+            tally.acted += 1
+        else:
+            tally.pending += 1
+            print(f"        {excess - removed} excess copy(ies) of {bucket}/{key} remain "
+                  f"on busy/read-only servers -- will converge on a future scrub")
+    verb = "reduced" if apply else "would reduce"
+    print(f"Reduction: checked {tally.checked}, at copy count {tally.ok}, "
+          f"{verb} {tally.acted}, pending {tally.pending}, anomalies {tally.anomalies}")
+    return tally
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -211,22 +356,29 @@ def main() -> int:
                         help="only the D/F media-deletion branch")
     branch.add_argument("--replicate-only", action="store_true",
                         help="only the A-band replication branch")
+    branch.add_argument("--reduce-only", action="store_true",
+                        help="only the below-B copy-reduction branch")
     parser.add_argument("--s3", help="simpler-objects locator base URL (default: $OBJIDX_S3)")
     args = parser.parse_args()
-    do_delete = not args.replicate_only
-    do_replicate = not args.delete_only
+    only = args.delete_only or args.replicate_only or args.reduce_only
+    do_delete = args.delete_only or not only
+    do_replicate = args.replicate_only or not only
+    do_reduce = args.reduce_only or not only
 
     objidx = oic.get_obj_idx_env()
-    locator = get_s3_base(args.s3) if do_replicate else None
+    locator = get_s3_base(args.s3)
     engine = create_engine(DATABASE_URL, echo=False)
     anomalies = 0
     with Session(engine) as session:
         if do_delete:
             anomalies += scrub_deletions(deletion_candidates(session), objidx,
-                                         args.apply).anomalies
+                                         locator, args.apply).anomalies
         if do_replicate:
             anomalies += scrub_replication(replication_candidates(session), objidx,
                                            locator, args.apply).anomalies
+        if do_reduce:
+            anomalies += scrub_reduction(reduction_candidates(session), objidx,
+                                         locator, args.apply).anomalies
     return 1 if anomalies else 0
 
 

--- a/lmdb/test_scrub_oi.py
+++ b/lmdb/test_scrub_oi.py
@@ -1,0 +1,261 @@
+"""Tests for lmdb.scrub_oi (the V4 OI scrubber, #111).
+
+Selection tests are DB-backed (throwaway PostgreSQL via pytest-postgresql, as in
+test_api.py) because the A-band set rides the compute-on-read machine-rating SQL.
+Action tests are pure logic (no DB, no network): a fake OI client plus monkeypatched
+locator/replication functions, in the test_job_runner.py style.
+"""
+
+import uuid
+from types import SimpleNamespace
+import httpx
+import pytest
+import requests
+from sqlmodel import Session, SQLModel, create_engine
+from pytest_postgresql import factories
+
+from lmdb import scrub_oi
+from lmdb.models import Thing, Rel
+
+# Fedora keeps pg_ctl in /usr/bin (pytest-postgresql's default assumes a Debian path).
+postgresql_proc = factories.postgresql_proc(executable="/usr/bin/pg_ctl")
+postgresql = factories.postgresql("postgresql_proc")
+
+
+@pytest.fixture
+def session(postgresql):
+    info = postgresql.info
+    auth = f"{info.user}:{info.password}@" if info.password else f"{info.user}@"
+    url = f"postgresql+psycopg://{auth}{info.host}:{info.port}/{info.dbname}"
+    engine = create_engine(url)
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as s:
+        yield s
+
+
+def _thing(session, *, rating=None, best_oi=False, container=False, url=None) -> Thing:
+    thing = Thing(url=url or f"http://example/{uuid.uuid4()}", bucket="b",
+                  container=container, human_rating=rating,
+                  best_oi=uuid.uuid4() if best_oi else None)
+    session.add(thing)
+    session.commit()
+    return thing
+
+
+# --- selection (DB-backed) --------------------------------------------------------------
+
+def test_deletion_candidates_human_df_with_media_only(session):
+    d = _thing(session, rating=-1.0, best_oi=True)
+    f = _thing(session, rating=-2.0, best_oi=True)
+    _thing(session, rating=-1.0, best_oi=False)   # D but never acquired
+    _thing(session, rating=0.0, best_oi=True)     # C
+    _thing(session, rating=1.0, best_oi=True)     # B
+    got = {t.id for t in scrub_oi.deletion_candidates(session)}
+    assert got == {d.id, f.id}
+
+
+def test_deletion_ignores_machine_rating(session):
+    # A video whose parent playlist is rated D assesses D by machine rating, but deletion
+    # is driven by *human* ratings only (§2.4/Appendix A).
+    parent = _thing(session, rating=-1.0, container=True)
+    video = _thing(session, rating=None, best_oi=True)
+    session.add(Rel(parent=parent.id, child=video.id))
+    session.commit()
+    assert scrub_oi.deletion_candidates(session) == []
+
+
+def test_replication_candidates_effective_a_band(session):
+    human_a = _thing(session, rating=2.0, best_oi=True)
+    parent = _thing(session, rating=2.0, container=True)
+    machine_a = _thing(session, rating=None, best_oi=True)
+    session.add(Rel(parent=parent.id, child=machine_a.id))
+    session.commit()
+    _thing(session, rating=1.0, best_oi=True)     # B: 1 copy is fine
+    _thing(session, rating=2.0, best_oi=False)    # A but never acquired
+    got = {t.id for t in scrub_oi.replication_candidates(session)}
+    assert got == {human_a.id, machine_a.id}
+
+
+def test_replication_human_rating_overrides_machine(session):
+    # Human F beats a machine A (human is authoritative, §2.4): not owed copies.
+    parent = _thing(session, rating=2.0, container=True)
+    video = _thing(session, rating=-2.0, best_oi=True)
+    session.add(Rel(parent=parent.id, child=video.id))
+    session.commit()
+    assert scrub_oi.replication_candidates(session) == []
+
+
+# --- fakes for the action tests ----------------------------------------------------------
+
+class FakeOI:
+    """obj_idx client stand-in: file UUID -> object dict; records PUTs.
+
+    `honor_delete` mimics a future OI that really tombstones (objectindex#23); False
+    mimics today's silent refusal for completed objects (the PUT returns it unchanged).
+    """
+
+    def __init__(self, objects: dict, honor_delete: bool = False):
+        self.objects = objects
+        self.honor_delete = honor_delete
+        self.puts = []
+
+    def get_file(self, fil_uuid):
+        obj = self.objects.get(fil_uuid)
+        if obj == "missing":
+            raise requests.HTTPError("404 File not found")
+        return SimpleNamespace(object=obj)
+
+    def put_object(self, obj_uuid, info):
+        self.puts.append((obj_uuid, info))
+        obj = next(o for o in self.objects.values()
+                   if o not in (None, "missing") and o["uuid"] == obj_uuid)
+        if self.honor_delete:
+            obj = {**obj, "deleted": True}
+        return obj
+
+
+def _mem_thing(rating=None) -> Thing:
+    return Thing(bucket="b", container=False, human_rating=rating, best_oi=uuid.uuid4())
+
+
+def _obj(completed=True, deleted=False, bucket="b", key="k", size=100):
+    return {"uuid": str(uuid.uuid4()), "bucket": bucket, "key": key,
+            "obj_size": size, "completed": completed, "deleted": deleted}
+
+
+# --- deletion actions ---------------------------------------------------------------------
+
+def test_delete_applied_and_honored():
+    thing = _mem_thing(rating=-1.0)
+    oi = FakeOI({thing.best_oi: _obj()}, honor_delete=True)
+    tally = scrub_oi.scrub_deletions([thing], oi, apply=True)
+    assert [p[1] for p in oi.puts] == [{"deleted": True}]
+    assert (tally.acted, tally.pending, tally.anomalies) == (1, 0, 0)
+
+
+def test_delete_refused_is_pending_not_anomaly():
+    # Today's OI: PUT deleted=True on a completed object comes back unchanged.
+    thing = _mem_thing(rating=-2.0)
+    oi = FakeOI({thing.best_oi: _obj()}, honor_delete=False)
+    tally = scrub_oi.scrub_deletions([thing], oi, apply=True)
+    assert len(oi.puts) == 1
+    assert (tally.acted, tally.pending, tally.anomalies) == (0, 1, 0)
+
+
+def test_delete_already_tombstoned_is_noop():
+    thing = _mem_thing(rating=-1.0)
+    oi = FakeOI({thing.best_oi: _obj(deleted=True)})
+    tally = scrub_oi.scrub_deletions([thing], oi, apply=True)
+    assert oi.puts == []
+    assert (tally.ok, tally.acted, tally.anomalies) == (1, 0, 0)
+
+
+def test_delete_dry_run_touches_nothing():
+    thing = _mem_thing(rating=-1.0)
+    oi = FakeOI({thing.best_oi: _obj()}, honor_delete=True)
+    tally = scrub_oi.scrub_deletions([thing], oi, apply=False)
+    assert oi.puts == []
+    assert tally.acted == 1  # reported as "would delete"
+
+
+def test_delete_missing_oi_file_is_anomaly():
+    thing = _mem_thing(rating=-1.0)
+    tally = scrub_oi.scrub_deletions([thing], FakeOI({thing.best_oi: "missing"}), apply=True)
+    assert (tally.anomalies, tally.acted) == (1, 0)
+
+
+# --- replication actions -------------------------------------------------------------------
+
+def _patch_locator(monkeypatch, listing, targets=("http://srv2/",)):
+    calls = {"replicated": [], "find_space": []}
+    monkeypatch.setattr(scrub_oi, "_bucket_listing", lambda locator, bucket: listing)
+    monkeypatch.setattr(scrub_oi, "find_space",
+                        lambda *a: calls["find_space"].append(a) or list(targets))
+    monkeypatch.setattr(scrub_oi, "replicate_object",
+                        lambda src, dst: calls["replicated"].append((src, dst)))
+    return calls
+
+
+def test_replicate_under_replicated(monkeypatch):
+    thing = _mem_thing(rating=2.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_locator(monkeypatch,
+                           {"k": {"locations": ["http://srv1/"], "error": None}})
+    tally = scrub_oi.scrub_replication([thing], oi, "http://loc/", apply=True)
+    assert calls["replicated"] == [("http://srv1/b/k", "http://srv2/b/k")]
+    assert (tally.acted, tally.anomalies) == (1, 0)
+
+
+def test_replicate_at_count_is_noop(monkeypatch):
+    thing = _mem_thing(rating=2.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_locator(
+        monkeypatch, {"k": {"locations": ["http://srv1/", "http://srv2/"], "error": None}})
+    tally = scrub_oi.scrub_replication([thing], oi, "http://loc/", apply=True)
+    assert calls["replicated"] == []
+    assert (tally.ok, tally.acted, tally.anomalies) == (1, 0, 0)
+
+
+def test_replicate_dry_run_touches_nothing(monkeypatch):
+    thing = _mem_thing(rating=2.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_locator(monkeypatch,
+                           {"k": {"locations": ["http://srv1/"], "error": None}})
+    tally = scrub_oi.scrub_replication([thing], oi, "http://loc/", apply=False)
+    assert calls["replicated"] == [] and calls["find_space"] == []
+    assert tally.acted == 1  # reported as "would replicate"
+
+
+@pytest.mark.parametrize("listing", [
+    {},                                          # key missing from the locator
+    {"k": {"locations": [], "error": None}},     # no copies anywhere
+])
+def test_replicate_lost_media_is_anomaly(monkeypatch, listing):
+    thing = _mem_thing(rating=2.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_locator(monkeypatch, listing)
+    tally = scrub_oi.scrub_replication([thing], oi, "http://loc/", apply=True)
+    assert calls["replicated"] == []
+    assert (tally.anomalies, tally.acted) == (1, 0)
+
+
+def test_replicate_locator_error_skips(monkeypatch):
+    # A copy may sit on a sleeping server (simpler-objects#76): flag, don't add a copy.
+    thing = _mem_thing(rating=2.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_locator(monkeypatch,
+                           {"k": {"locations": ["http://srv1/"], "error": "down"}})
+    tally = scrub_oi.scrub_replication([thing], oi, "http://loc/", apply=True)
+    assert calls["replicated"] == []
+    assert tally.anomalies == 1
+
+
+def test_replicate_tombstoned_a_band_is_anomaly(monkeypatch):
+    thing = _mem_thing(rating=2.0)
+    oi = FakeOI({thing.best_oi: _obj(deleted=True)})
+    calls = _patch_locator(monkeypatch, {"k": {"locations": ["http://srv1/"], "error": None}})
+    tally = scrub_oi.scrub_replication([thing], oi, "http://loc/", apply=True)
+    assert calls["replicated"] == []
+    assert tally.anomalies == 1
+
+
+def test_replicate_no_space_is_anomaly(monkeypatch):
+    thing = _mem_thing(rating=2.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_locator(monkeypatch,
+                           {"k": {"locations": ["http://srv1/"], "error": None}},
+                           targets=())
+    tally = scrub_oi.scrub_replication([thing], oi, "http://loc/", apply=True)
+    assert calls["replicated"] == []
+    assert (tally.anomalies, tally.acted) == (1, 0)
+
+
+def test_replicate_listing_unavailable_is_anomaly(monkeypatch):
+    thing = _mem_thing(rating=2.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+
+    def boom(locator, bucket):
+        raise httpx.HTTPError("503")
+    monkeypatch.setattr(scrub_oi, "_bucket_listing", boom)
+    tally = scrub_oi.scrub_replication([thing], oi, "http://loc/", apply=True)
+    assert tally.anomalies == 1

--- a/lmdb/test_scrub_oi.py
+++ b/lmdb/test_scrub_oi.py
@@ -1,9 +1,9 @@
 """Tests for lmdb.scrub_oi (the V4 OI scrubber, #111).
 
 Selection tests are DB-backed (throwaway PostgreSQL via pytest-postgresql, as in
-test_api.py) because the A-band set rides the compute-on-read machine-rating SQL.
+test_api.py) because the band cohorts ride the compute-on-read machine-rating SQL.
 Action tests are pure logic (no DB, no network): a fake OI client plus monkeypatched
-locator/replication functions, in the test_job_runner.py style.
+locator/replication/deletion functions, in the test_job_runner.py style.
 """
 
 import uuid
@@ -85,33 +85,34 @@ def test_replication_human_rating_overrides_machine(session):
     assert scrub_oi.replication_candidates(session) == []
 
 
+def test_reduction_candidates_below_b_not_human_df(session):
+    human_c = _thing(session, rating=0.0, best_oi=True)
+    unrated = _thing(session, rating=None, best_oi=True)   # effective defaults to 0 = C
+    parent = _thing(session, rating=-1.0, container=True)
+    machine_d = _thing(session, rating=None, best_oi=True)  # machine-D reduces, not deletes
+    session.add(Rel(parent=parent.id, child=machine_d.id))
+    session.commit()
+    _thing(session, rating=1.0, best_oi=True)    # B: untouched either way
+    _thing(session, rating=2.0, best_oi=True)    # A: the replication branch's cohort
+    _thing(session, rating=-1.0, best_oi=True)   # human D: the deletion branch's cohort
+    _thing(session, rating=0.0, best_oi=False)   # C but never acquired
+    got = {t.id for t in scrub_oi.reduction_candidates(session)}
+    assert got == {human_c.id, unrated.id, machine_d.id}
+
+
 # --- fakes for the action tests ----------------------------------------------------------
 
 class FakeOI:
-    """obj_idx client stand-in: file UUID -> object dict; records PUTs.
+    """obj_idx client stand-in: file UUID -> object dict."""
 
-    `honor_delete` mimics a future OI that really tombstones (objectindex#23); False
-    mimics today's silent refusal for completed objects (the PUT returns it unchanged).
-    """
-
-    def __init__(self, objects: dict, honor_delete: bool = False):
+    def __init__(self, objects: dict):
         self.objects = objects
-        self.honor_delete = honor_delete
-        self.puts = []
 
     def get_file(self, fil_uuid):
         obj = self.objects.get(fil_uuid)
         if obj == "missing":
             raise requests.HTTPError("404 File not found")
         return SimpleNamespace(object=obj)
-
-    def put_object(self, obj_uuid, info):
-        self.puts.append((obj_uuid, info))
-        obj = next(o for o in self.objects.values()
-                   if o not in (None, "missing") and o["uuid"] == obj_uuid)
-        if self.honor_delete:
-            obj = {**obj, "deleted": True}
-        return obj
 
 
 def _mem_thing(rating=None) -> Thing:
@@ -125,42 +126,84 @@ def _obj(completed=True, deleted=False, bucket="b", key="k", size=100):
 
 # --- deletion actions ---------------------------------------------------------------------
 
-def test_delete_applied_and_honored():
+def _patch_delete(monkeypatch, result=True):
+    """Fake oic.delete_object_data (raising=False: the installed obj_idx may predate
+    0.3.8, where the function first appears); an Exception result is raised."""
+    calls = []
+
+    def fake(objidx, objid, locator):
+        calls.append((objid, locator))
+        if isinstance(result, Exception):
+            raise result
+        return result
+    monkeypatch.setattr(scrub_oi.oic, "delete_object_data", fake, raising=False)
+    return calls
+
+
+def test_delete_applied_and_confirmed(monkeypatch):
     thing = _mem_thing(rating=-1.0)
-    oi = FakeOI({thing.best_oi: _obj()}, honor_delete=True)
-    tally = scrub_oi.scrub_deletions([thing], oi, apply=True)
-    assert [p[1] for p in oi.puts] == [{"deleted": True}]
+    obj = _obj()
+    calls = _patch_delete(monkeypatch, result=True)
+    tally = scrub_oi.scrub_deletions([thing], FakeOI({thing.best_oi: obj}),
+                                     "http://loc/", apply=True)
+    assert calls == [(obj["uuid"], "http://loc/")]
     assert (tally.acted, tally.pending, tally.anomalies) == (1, 0, 0)
 
 
-def test_delete_refused_is_pending_not_anomaly():
-    # Today's OI: PUT deleted=True on a completed object comes back unchanged.
+def test_delete_unconfirmed_is_pending_not_anomaly(monkeypatch):
+    # delete_object_data ran out of retries (a store server busy/unreachable): the
+    # record is left unmarked and a future scrub converges.
     thing = _mem_thing(rating=-2.0)
-    oi = FakeOI({thing.best_oi: _obj()}, honor_delete=False)
-    tally = scrub_oi.scrub_deletions([thing], oi, apply=True)
-    assert len(oi.puts) == 1
+    calls = _patch_delete(monkeypatch, result=False)
+    tally = scrub_oi.scrub_deletions([thing], FakeOI({thing.best_oi: _obj()}),
+                                     "http://loc/", apply=True)
+    assert len(calls) == 1
     assert (tally.acted, tally.pending, tally.anomalies) == (0, 1, 0)
 
 
-def test_delete_already_tombstoned_is_noop():
+def test_delete_never_completed_is_anomaly(monkeypatch):
+    # best_oi behind an incomplete upload: delete_object_data refuses (ValueError,
+    # scrub --clear territory) rather than tombstoning the key mid-upload.
     thing = _mem_thing(rating=-1.0)
-    oi = FakeOI({thing.best_oi: _obj(deleted=True)})
-    tally = scrub_oi.scrub_deletions([thing], oi, apply=True)
-    assert oi.puts == []
+    _patch_delete(monkeypatch, result=ValueError("upload not completed"))
+    tally = scrub_oi.scrub_deletions([thing], FakeOI({thing.best_oi: _obj()}),
+                                     "http://loc/", apply=True)
+    assert (tally.anomalies, tally.acted, tally.pending) == (1, 0, 0)
+
+
+def test_delete_http_error_is_anomaly(monkeypatch):
+    # e.g. the locator identity lacks the `delete` RBAC permission (401/403).
+    thing = _mem_thing(rating=-1.0)
+    _patch_delete(monkeypatch, result=requests.HTTPError("403 Forbidden"))
+    tally = scrub_oi.scrub_deletions([thing], FakeOI({thing.best_oi: _obj()}),
+                                     "http://loc/", apply=True)
+    assert (tally.anomalies, tally.acted, tally.pending) == (1, 0, 0)
+
+
+def test_delete_already_tombstoned_is_noop(monkeypatch):
+    thing = _mem_thing(rating=-1.0)
+    calls = _patch_delete(monkeypatch)
+    tally = scrub_oi.scrub_deletions([thing], FakeOI({thing.best_oi: _obj(deleted=True)}),
+                                     "http://loc/", apply=True)
+    assert calls == []
     assert (tally.ok, tally.acted, tally.anomalies) == (1, 0, 0)
 
 
-def test_delete_dry_run_touches_nothing():
+def test_delete_dry_run_touches_nothing(monkeypatch):
     thing = _mem_thing(rating=-1.0)
-    oi = FakeOI({thing.best_oi: _obj()}, honor_delete=True)
-    tally = scrub_oi.scrub_deletions([thing], oi, apply=False)
-    assert oi.puts == []
+    calls = _patch_delete(monkeypatch)
+    tally = scrub_oi.scrub_deletions([thing], FakeOI({thing.best_oi: _obj()}),
+                                     "http://loc/", apply=False)
+    assert calls == []
     assert tally.acted == 1  # reported as "would delete"
 
 
-def test_delete_missing_oi_file_is_anomaly():
+def test_delete_missing_oi_file_is_anomaly(monkeypatch):
     thing = _mem_thing(rating=-1.0)
-    tally = scrub_oi.scrub_deletions([thing], FakeOI({thing.best_oi: "missing"}), apply=True)
+    calls = _patch_delete(monkeypatch)
+    tally = scrub_oi.scrub_deletions([thing], FakeOI({thing.best_oi: "missing"}),
+                                     "http://loc/", apply=True)
+    assert calls == []
     assert (tally.anomalies, tally.acted) == (1, 0)
 
 
@@ -258,4 +301,135 @@ def test_replicate_listing_unavailable_is_anomaly(monkeypatch):
         raise httpx.HTTPError("503")
     monkeypatch.setattr(scrub_oi, "_bucket_listing", boom)
     tally = scrub_oi.scrub_replication([thing], oi, "http://loc/", apply=True)
+    assert tally.anomalies == 1
+
+
+# --- reduction actions ---------------------------------------------------------------------
+
+SRV1, SRV2, SRV3 = "http://srv1/", "http://srv2/", "http://srv3/"
+
+
+def _patch_reduction(monkeypatch, locations, used, statuses=()):
+    """Wire a one-key listing, a fake health map, and a status-scripted _delete_copy."""
+    calls = {"deleted": []}
+    monkeypatch.setattr(scrub_oi, "_bucket_listing",
+                        lambda locator, bucket: {"k": {"locations": list(locations),
+                                                       "error": None}})
+    monkeypatch.setattr(scrub_oi, "_server_used_bytes", lambda locator: used)
+
+    def fake_delete(server, bucket, key):
+        calls["deleted"].append(server)
+        return dict(statuses).get(server, 204)
+    monkeypatch.setattr(scrub_oi, "_delete_copy", fake_delete)
+    return calls
+
+
+def test_reduce_deletes_copy_on_fullest_server(monkeypatch):
+    thing = _mem_thing(rating=0.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_reduction(monkeypatch, [SRV1, SRV2], {SRV1: 10, SRV2: 999})
+    tally = scrub_oi.scrub_reduction([thing], oi, "http://loc/", apply=True)
+    assert calls["deleted"] == [SRV2]
+    assert (tally.acted, tally.pending, tally.anomalies) == (1, 0, 0)
+
+
+def test_reduce_three_copies_keeps_least_used(monkeypatch):
+    thing = _mem_thing(rating=0.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_reduction(monkeypatch, [SRV1, SRV2, SRV3],
+                             {SRV1: 5, SRV2: 50, SRV3: 500})
+    tally = scrub_oi.scrub_reduction([thing], oi, "http://loc/", apply=True)
+    assert calls["deleted"] == [SRV3, SRV2]  # fullest first; SRV1 survives
+    assert (tally.acted, tally.anomalies) == (1, 0)
+
+
+def test_reduce_at_one_copy_is_noop(monkeypatch):
+    thing = _mem_thing(rating=0.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_reduction(monkeypatch, [SRV1], {SRV1: 10})
+    tally = scrub_oi.scrub_reduction([thing], oi, "http://loc/", apply=True)
+    assert calls["deleted"] == []
+    assert (tally.ok, tally.acted, tally.anomalies) == (1, 0, 0)
+
+
+def test_reduce_dry_run_touches_nothing(monkeypatch):
+    thing = _mem_thing(rating=0.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_reduction(monkeypatch, [SRV1, SRV2], {SRV1: 10, SRV2: 999})
+    tally = scrub_oi.scrub_reduction([thing], oi, "http://loc/", apply=False)
+    assert calls["deleted"] == []
+    assert tally.acted == 1  # reported as "would reduce"
+
+
+def test_reduce_busy_server_falls_through_to_next(monkeypatch):
+    # Fullest copy is mid-upload/read-only: the next-fullest goes instead.
+    thing = _mem_thing(rating=0.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_reduction(monkeypatch, [SRV1, SRV2], {SRV1: 999, SRV2: 10},
+                             statuses={SRV1: 503})
+    tally = scrub_oi.scrub_reduction([thing], oi, "http://loc/", apply=True)
+    assert calls["deleted"] == [SRV1, SRV2]
+    assert (tally.acted, tally.pending, tally.anomalies) == (1, 0, 0)
+
+
+def test_reduce_all_copies_busy_is_pending_not_anomaly(monkeypatch):
+    thing = _mem_thing(rating=0.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_reduction(monkeypatch, [SRV1, SRV2], {SRV1: 999, SRV2: 10},
+                             statuses={SRV1: 503, SRV2: 405})
+    tally = scrub_oi.scrub_reduction([thing], oi, "http://loc/", apply=True)
+    assert calls["deleted"] == [SRV1, SRV2]
+    assert (tally.acted, tally.pending, tally.anomalies) == (0, 1, 0)
+
+
+def test_reduce_stale_listing_404_counts_as_removed(monkeypatch):
+    thing = _mem_thing(rating=0.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_reduction(monkeypatch, [SRV1, SRV2], {SRV1: 999, SRV2: 10},
+                             statuses={SRV1: 404})
+    tally = scrub_oi.scrub_reduction([thing], oi, "http://loc/", apply=True)
+    assert calls["deleted"] == [SRV1]
+    assert (tally.acted, tally.anomalies) == (1, 0)
+
+
+def test_reduce_hard_error_is_anomaly(monkeypatch):
+    thing = _mem_thing(rating=0.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_reduction(monkeypatch, [SRV1, SRV2], {SRV1: 999, SRV2: 10},
+                             statuses={SRV1: 500})
+    tally = scrub_oi.scrub_reduction([thing], oi, "http://loc/", apply=True)
+    assert calls["deleted"] == [SRV1]
+    assert (tally.acted, tally.anomalies) == (0, 1)
+
+
+def test_reduce_tombstoned_is_converged(monkeypatch):
+    # A deleted-then-re-rated-up-to-C thing: nothing held, nothing to trim.
+    thing = _mem_thing(rating=0.0)
+    oi = FakeOI({thing.best_oi: _obj(deleted=True)})
+    calls = _patch_reduction(monkeypatch, [SRV1, SRV2], {SRV1: 10, SRV2: 999})
+    tally = scrub_oi.scrub_reduction([thing], oi, "http://loc/", apply=True)
+    assert calls["deleted"] == []
+    assert (tally.ok, tally.anomalies) == (1, 0)
+
+
+def test_reduce_incomplete_object_is_anomaly(monkeypatch):
+    thing = _mem_thing(rating=0.0)
+    oi = FakeOI({thing.best_oi: _obj(completed=False)})
+    calls = _patch_reduction(monkeypatch, [SRV1, SRV2], {SRV1: 10, SRV2: 999})
+    tally = scrub_oi.scrub_reduction([thing], oi, "http://loc/", apply=True)
+    assert calls["deleted"] == []
+    assert tally.anomalies == 1
+
+
+def test_reduce_locator_error_flag_skips(monkeypatch):
+    # A copy may sit on a sleeping server (simpler-objects#76): deleting a visible
+    # copy could orphan the key onto only the unreachable server. Flag, don't act.
+    thing = _mem_thing(rating=0.0)
+    oi = FakeOI({thing.best_oi: _obj()})
+    calls = _patch_reduction(monkeypatch, [SRV1, SRV2], {SRV1: 10, SRV2: 999})
+    monkeypatch.setattr(scrub_oi, "_bucket_listing",
+                        lambda locator, bucket: {"k": {"locations": [SRV1, SRV2],
+                                                       "error": "down"}})
+    tally = scrub_oi.scrub_reduction([thing], oi, "http://loc/", apply=True)
+    assert calls["deleted"] == []
     assert tally.anomalies == 1


### PR DESCRIPTION
The 4.1 OI-scrubber slice from `LM-V4-DESIGN.md` Appendix A / §2.4: `python -m lmdb.scrub_oi` reconciles LM ratings against OI/SO media holdings. Dry-run by default, `--apply` to act, `--delete-only`/`--replicate-only`/`--reduce-only` to run one branch; exits nonzero iff anomalies. The scrubber never writes the LM database.

**Depends on two open upstream PRs** (deploy them first; the code needs obj_idx ≥ 0.3.8 and simpler-objects ≥ 0.6.0):
- [ ] ctengel/objectindex#102 — client-driven object deletion (`client.delete_object_data`: locator fan-out DELETE + `completed+deleted` record PUT)
- [ ] ctengel/simpler-objects#85 — `DELETE /{bucket}/{key}` at both tiers (locator fan-out for full deletion; direct object-server DELETE for single-copy reduction)

## What it does — copy policy by effective rating band (§2.4)
| Band | Rule |
|---|---|
| A (≥ +1.5) | floor 2 copies — replicated up via the SO locator (`simpler_objects.async_replicate`); extras never trimmed |
| B | untouched |
| C and below, not human-D/F (incl. unrated, machine-D/F) | ceiling 1 copy — excess copies DELETEd directly on their object server, **fullest server (`quota-used-bytes`) first**; a 503/405 server shifts the delete to the next-fullest copy (pending if none remain) |
| human-D/F | media deleted outright (machine ratings never delete) |

- **D/F media deletion** — `delete_object_data` removes every SO copy through the locator (retrying per `Retry-After`) and marks the OI record `completed+deleted`. `best_oi` needs no repoint: it is the OI *file* UUID, whose object simply becomes the tombstone. "Pending" now means the store was busy/unreachable; rerunning converges.
- **A-band replication** — unchanged from the first commit: things ≥ +1.5 effective (reuses `api._effective_rating_expr`) are brought up to 2 copies via `find_space`/`replicate_object`. Lost media, tombstoned-but-A, no-space, and locator-error cases are anomalies; per-key locator `error` entries are skipped (sleeping-disk guard, simpler-objects#76 — same guard applies to reduction, since deleting a visible copy could orphan the key onto an unreachable server).
- **Known SO-side consequences** (by upstream design): each single-copy delete leaves a write-once checksum tombstone on that server — the key can never be re-placed there (a later C→A re-promotion must replicate elsewhere) — and a stale scrub entry until the operator runs `--repair-checksums`.

## Out of scope (stays open in #111)
Load/import + redownload-lost branches and the F-only metadata purge.

## Testing
- 32 tests in `lmdb/test_scrub_oi.py`: DB-backed cohort selection (band floors, human-only deletion, machine-A inclusion, human-F-overrides-machine-A, reduction excludes B/A/human-D/F) + monkeypatched action/anomaly paths for all three branches (incl. fullest-server victim ordering, 503/405 fall-through, stale-404, all-busy pending). Full `test_api.py`/`test_xform.py` unaffected (155 pass).
- Live end-to-end smoke against a throwaway stack (2 SO object servers + locator on the `object-delete` branch, OI API on `deletion-23`, scratch Postgres): dry-run touches nothing; `--apply` deletes the F object's bytes + marks its record `completed+deleted` (locator GET 404, tombstone lines intact), replicates the A object to 2 copies, and trims the C object's second copy; rerun converges cleanly (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)