### PR TITLE
lmdb: stop the facet native_id tab-eats-tab merge cascade (#196)

### DIFF
--- a/lmdb/api.py
+++ b/lmdb/api.py
@@ -729,13 +729,16 @@ def _fanout(session: Session, pull: models.PullThing, container: Thing,
     # sibling already holds it the clash must never converge (`facet_native` below) — the holder
     # is a different tab/URL-variant of the same channel, and merging would delete it and let the
     # next sibling pull eat the new holder in turn (tab-eats-tab cascade). Keep the id as a soft
-    # channel_id hint either way.
+    # channel_id hint either way — in the raw channel_id namespace when known, so this write
+    # agrees with the parent-fed one above (merge_attr overwrites; a pull.native_id in the
+    # @handle form would otherwise flip the stored hint between namespaces across pulls).
     # Matched against both uploader ids (xform.owns_native_id): a tab's own id equals the raw
     # channel_id while UlChan.native_id prefers the @handle-form uploader_id (#217), so the
     # single-field compare left this guard dead on real youtube tab pulls.
     facet_pull = xform.owns_native_id(pull.native_id, pull.channel)
     if facet_pull and graph.playlist.url is not None:
-        xform.merge_attr(container, "channel_id", pull.native_id)
+        xform.merge_attr(container, "channel_id",
+                         pull.channel.channel_id or pull.native_id)
 
     # The recorded thing IS the container: backfill it, classify it, mark success.
     merged.update(_apply_backfill(session, container, graph.playlist,

--- a/lmdb/api.py
+++ b/lmdb/api.py
@@ -522,15 +522,18 @@ def _merge_things(session: Session, survivor: Thing, loser: Thing) -> None:
         survivor.attrs = {**loser_attrs, **(survivor.attrs or {})}
 
 
-def _apply_backfill(session: Session, existing: Thing,
-                    incoming: Thing) -> list[tuple[uuid.UUID, uuid.UUID]]:
+def _apply_backfill(session: Session, existing: Thing, incoming: Thing,
+                    facet_native: bool = False) -> list[tuple[uuid.UUID, uuid.UUID]]:
     """Fill NULL fields on `existing` from `incoming` (#147), converging any duplicate row.
 
     `null_backfill` proposes the still-NULL fields. If proposing `native_id` (thing_native) or
     `url` (thing_url) would collide with a *different* row, that row is a duplicate of the same
     real thing: merge it into `existing` (`_merge_things`) so the proposed value is free, then
     apply it. Both partial-unique indexes flow through the one merge path — except a *channel*
-    clash, which is never converged away (see the guard below).
+    clash, which is never converged away (see the guard below), and a `facet_native` clash:
+    the caller marks the proposed native_id as a channel's shared/facet id (the pull IS its
+    own uploader), where same id does NOT mean same thing — the holder may be a sibling tab —
+    so the claim is dropped and `existing` stays URL-keyed instead of merging.
 
     Returns the merges performed as `(loser_id, survivor_id)` pairs (normally empty), so a
     caller holding ids to merged-away rows (`_fanout`'s remap) can re-resolve them.
@@ -572,6 +575,14 @@ def _apply_backfill(session: Session, existing: Thing,
         if xform.is_channel(clash):
             for field in clash_fields:
                 fields.pop(field, None)
+            continue
+        # A facet native_id (the pull's own uploader id, shared by every tab of the channel) is
+        # never evidence the holder is a duplicate — it is usually a sibling tab or URL-variant,
+        # and merging would delete it and hand the id to `existing`, whose next sibling's pull
+        # then eats *it* (tab-eats-tab cascade). Drop the claim; `existing` stays URL-keyed. A
+        # same-row url clash still marks a true duplicate and converges as usual.
+        if facet_native and clash_fields == ["native_id"]:
+            fields.pop("native_id", None)
             continue
         _merge_things(session, existing, clash)
         merged.append((clash.id, existing.id))
@@ -707,8 +718,20 @@ def _fanout(session: Session, pull: models.PullThing, container: Thing,
         xform.merge_attr(container, "channel_id", graph.playlist.native_id)
         graph.playlist.native_id = None
 
+    # A top-level pull that IS its own uploader (a channel or one of its tabs) carries a *facet*
+    # id: every tab of the channel reports the same native_id. Claiming it when free is fine
+    # (that's how a directly-pulled channel gains the id #160 linking relies on), but when a
+    # sibling already holds it the clash must never converge (`facet_native` below) — the holder
+    # is a different tab/URL-variant of the same channel, and merging would delete it and let the
+    # next sibling pull eat the new holder in turn (tab-eats-tab cascade). Keep the id as a soft
+    # channel_id hint either way.
+    facet_pull = pull.native_id is not None and pull.native_id == pull.channel.native_id
+    if facet_pull and graph.playlist.url is not None:
+        xform.merge_attr(container, "channel_id", pull.native_id)
+
     # The recorded thing IS the container: backfill it, classify it, mark success.
-    merged.update(_apply_backfill(session, container, graph.playlist))
+    merged.update(_apply_backfill(session, container, graph.playlist,
+                                  facet_native=facet_pull))
     container.container = True
     container.last_success_dt = now
     xform.clear_info_hint(container)   # "just a playlist": hint cleared after its own pull

--- a/lmdb/api.py
+++ b/lmdb/api.py
@@ -611,8 +611,13 @@ def _fanout_video_channel(session: Session, video: Thing, chan: models.UlChan) -
         chan_id = stub.id
     else:
         chan_id = existing.id
+    # The full extract proves this parent IS the video's uploader, so an existing plain
+    # membership edge for the pair (V3-migrated data, or a channel first pulled as an anonymous
+    # playlist) upgrades to channel=True — `_upsert_rels`' monotonic OR, which for an
+    # always-True incoming edge is a plain set (never downgrades; Stage-1 can't demote it back).
     session.execute(pg_insert(Rel).values(
-        parent=chan_id, child=video.id, channel=True).on_conflict_do_nothing())
+        parent=chan_id, child=video.id, channel=True).on_conflict_do_update(
+            index_elements=["parent", "child"], set_={"channel": True}))
 
 
 def _converge_urlless_channel(session: Session,

--- a/lmdb/api.py
+++ b/lmdb/api.py
@@ -725,7 +725,10 @@ def _fanout(session: Session, pull: models.PullThing, container: Thing,
     # is a different tab/URL-variant of the same channel, and merging would delete it and let the
     # next sibling pull eat the new holder in turn (tab-eats-tab cascade). Keep the id as a soft
     # channel_id hint either way.
-    facet_pull = pull.native_id is not None and pull.native_id == pull.channel.native_id
+    # Matched against both uploader ids (xform.owns_native_id): a tab's own id equals the raw
+    # channel_id while UlChan.native_id prefers the @handle-form uploader_id (#217), so the
+    # single-field compare left this guard dead on real youtube tab pulls.
+    facet_pull = xform.owns_native_id(pull.native_id, pull.channel)
     if facet_pull and graph.playlist.url is not None:
         xform.merge_attr(container, "channel_id", pull.native_id)
 
@@ -866,9 +869,11 @@ def claim_job(item: ClaimRequest, session: Session = Depends(get_session)):
         Thing.best_oi == None, Thing.try_on <= today)  # noqa: E711
     # Stage-2 video meta-only: C-band leaf the flat pull under-described (no human-decision
     # metadata yet, last_success_dt NULL). Fetches metadata only — no media, no best_oi.
+    # A meta exists to make the thing rateable, so an already-human-rated leaf never needs
+    # one (#217): skip it even while its stored metadata stays formally incomplete.
     meta_branch = sa.and_(
         Thing.container == False, rating >= _PLAYLIST_FLOOR,  # noqa: E712
-        rating < _VIDEO_DOWNLOAD_FLOOR,
+        rating < _VIDEO_DOWNLOAD_FLOOR, Thing.human_rating == None,  # noqa: E711
         Thing.last_success_dt == None, Thing.best_oi == None,  # noqa: E711
         Thing.try_on <= today)
     # Exclude things with a fresh in-progress run (success IS NULL, claimed within the lease):

--- a/lmdb/api.py
+++ b/lmdb/api.py
@@ -581,7 +581,7 @@ def _apply_backfill(session: Session, existing: Thing, incoming: Thing,
         # and merging would delete it and hand the id to `existing`, whose next sibling's pull
         # then eats *it* (tab-eats-tab cascade). Drop the claim; `existing` stays URL-keyed. A
         # same-row url clash still marks a true duplicate and converges as usual.
-        if facet_native and clash_fields == ["native_id"]:
+        if facet_native and "url" not in clash_fields:
             fields.pop("native_id", None)
             continue
         _merge_things(session, existing, clash)
@@ -604,6 +604,11 @@ def _fanout_video_channel(session: Session, video: Thing, chan: models.UlChan) -
     if stub is None:
         return
     existing = _find_thing(session, stub)
+    if existing is not None and existing.id == video.id:
+        # An extractor whose uploader_url equals the video's own webpage_url resolves the
+        # uploader to the video itself — never insert the (v, v, channel=True) self-loop,
+        # which would also satisfy 160_backfill's orphan anti-join and hide the video from it.
+        return
     if existing is None:
         stub.bucket = video.bucket
         session.add(stub)
@@ -723,22 +728,20 @@ def _fanout(session: Session, pull: models.PullThing, container: Thing,
         xform.merge_attr(container, "channel_id", graph.playlist.native_id)
         graph.playlist.native_id = None
 
-    # A top-level pull that IS its own uploader (a channel or one of its tabs) carries a *facet*
-    # id: every tab of the channel reports the same native_id. Claiming it when free is fine
-    # (that's how a directly-pulled channel gains the id #160 linking relies on), but when a
-    # sibling already holds it the clash must never converge (`facet_native` below) — the holder
-    # is a different tab/URL-variant of the same channel, and merging would delete it and let the
-    # next sibling pull eat the new holder in turn (tab-eats-tab cascade). Keep the id as a soft
-    # channel_id hint either way — in the raw channel_id namespace when known, so this write
-    # agrees with the parent-fed one above (merge_attr overwrites; a pull.native_id in the
-    # @handle form would otherwise flip the stored hint between namespaces across pulls).
-    # Matched against both uploader ids (xform.owns_native_id): a tab's own id equals the raw
-    # channel_id while UlChan.native_id prefers the @handle-form uploader_id (#217), so the
-    # single-field compare left this guard dead on real youtube tab pulls.
-    facet_pull = xform.owns_native_id(pull.native_id, pull.channel)
+    # A top-level pull that IS its own uploader (a channel or one of its tabs,
+    # `pl_full2things`' `_same_identity` verdict) carries a *facet* id: every tab of the
+    # channel reports the same native_id. Claiming it when free is fine (that's how a
+    # directly-pulled channel gains the id #160 linking relies on), but when a sibling already
+    # holds it the clash must never converge (`facet_native` below) — the holder is a
+    # different tab/URL-variant of the same channel, and merging would delete it and let the
+    # next sibling pull eat the new holder in turn (tab-eats-tab cascade). Keep the id as a
+    # soft channel_id hint either way — in the raw channel_id namespace when known, so this
+    # write agrees with the parent-fed one above (merge_attr overwrites; a pull.native_id in
+    # the @handle form would otherwise flip the stored hint between namespaces across pulls).
+    facet_pull = graph.pull_is_channel
     if facet_pull and graph.playlist.url is not None:
-        xform.merge_attr(container, "channel_id",
-                         pull.channel.channel_id or pull.native_id)
+        if (hint := pull.channel.channel_id or pull.native_id) is not None:
+            xform.merge_attr(container, "channel_id", hint)
 
     # The recorded thing IS the container: backfill it, classify it, mark success.
     merged.update(_apply_backfill(session, container, graph.playlist,

--- a/lmdb/models.py
+++ b/lmdb/models.py
@@ -27,6 +27,10 @@ class UlChan(BaseModel):
     """Minimal uploader/channel identity for channel fan-out (worker pre-resolves)."""
     url: Optional[str] = None         # best uploader/channel URL (uploader_url or channel_url)
     native_id: Optional[str] = None   # uploader_id or channel_id
+    # Raw channel_id, carried alongside because yt-dlp's uploader_id and channel_id are
+    # different namespaces (youtube: @handle vs UC…) and a container's own id can match either
+    # (both shapes seen live) — self-ownership tests (xform.owns_native_id) must check both.
+    channel_id: Optional[str] = None
     title: Optional[str] = None       # uploader
 
 class PullThing(BaseModel):

--- a/lmdb/run_bknd.py
+++ b/lmdb/run_bknd.py
@@ -87,9 +87,14 @@ def _norm_extractor(info: dict) -> Optional[str]:
 
 
 def _pull_chan(info: dict) -> models.UlChan:
-    """Resolve the best uploader/channel identity from a playlist or entry dict."""
+    """Resolve the best uploader/channel identity from a playlist or entry dict.
+
+    `channel_id` rides alongside the collapsed `native_id`: yt-dlp's uploader_id and
+    channel_id are different namespaces (youtube: @handle vs UC…), and a channel tab's own
+    playlist id matches channel_id, not uploader_id — self-ownership tests need both."""
     return models.UlChan(url=info.get("uploader_url") or info.get("channel_url"),
                            native_id=info.get("uploader_id") or info.get("channel_id"),
+                           channel_id=info.get("channel_id"),
                            title=info.get("uploader"))
 
 

--- a/lmdb/schema/160_backfill.py
+++ b/lmdb/schema/160_backfill.py
@@ -1,0 +1,73 @@
+"""One-off #160 backfill: link already-downloaded videos to their uploader channels.
+
+The #160 fan-out links a video to its channel at ingest time (Stage-1 pull, Stage-2
+meta/download), so a video acquired before it landed is never linked: it is terminal
+(`try_on` NULL, meta gated out) and nothing revisits it — and for the id-only sites
+(twitch/vk, ...) a playlist re-pull can't heal it either, since their flat entries carry
+no uploader fields at all. But the raw yt-dlp info dict of the download survives in the
+run's `data_json`, so this replays just the channel fan-out from there, through the
+production path (`run_bknd._pull_chan` -> `api._fanout_video_channel`): identical dedup
+(the site-scoped id join), identical url-less stub shape + provenance, and a later direct
+channel pull still absorbs the stubs (`_converge_urlless_channel`) exactly as if the
+video had been downloaded today.
+
+Idempotent — a re-run finds no orphans (linked videos now have a channel edge). NB parity
+cuts both ways: an orphan whose uploader came with a URL spawns a regular URL-keyed
+channel container, claimable as a Stage-1 pull (`try_on` today), just as a fresh download
+would.
+
+Run once from the repo root, after the #160 code is deployed:
+
+    PYTHONPATH=. DATABASE_URL=postgresql+psycopg:///lmdb python lmdb/schema/160_backfill.py
+"""
+
+import sqlalchemy as sa
+from sqlmodel import Session, select
+
+from lmdb import run_bknd
+from lmdb.api import engine, _fanout_video_channel
+from lmdb.models import Rel, Run, Thing
+
+
+def backfill(session: Session) -> dict[str, int]:
+    """Link every metadata-complete leaf that has no channel edge; returns outcome counts."""
+    counts = {"linked": 0, "no_uploader": 0, "no_video_run": 0}
+    orphan = ~sa.exists().where(sa.and_(Rel.child == Thing.id, Rel.channel == sa.true()))
+    vids = session.exec(
+        select(Thing).where(Thing.container == False,  # noqa: E712  (SQL IS FALSE, never NULL)
+                            Thing.last_success_dt != None,  # noqa: E711
+                            orphan)).all()
+    for vid in vids:
+        run = session.exec(
+            select(Run).where(Run.thing_id == vid.id,
+                              Run.success == True,  # noqa: E712
+                              Run.data_json != None)  # noqa: E711
+            .order_by(sa.desc(Run.starttime))).first()
+        info = run.data_json if run is not None else None
+        # A stray container-shaped data_json (a re-classified thing's old pull) is not this
+        # video's extract; skip rather than mis-read a playlist's uploader as the video's.
+        if not isinstance(info, dict) or run_bknd.is_container(info):
+            counts["no_video_run"] += 1
+            continue
+        chan = run_bknd._pull_chan(info)
+        if not chan.url and chan.native_id is None:
+            # Nothing to key a channel on (thing_from_chan would return None) — includes
+            # v3-migration synthetic runs whose data_json is just {'source': ...}.
+            counts["no_uploader"] += 1
+            continue
+        _fanout_video_channel(session, vid, chan)
+        counts["linked"] += 1
+    return counts
+
+
+def main() -> None:
+    with Session(engine) as session:
+        counts = backfill(session)
+        session.commit()
+    print(f"linked {counts['linked']} videos to channels; skipped "
+          f"{counts['no_uploader']} with no uploader info, "
+          f"{counts['no_video_run']} with no single-video run data")
+
+
+if __name__ == "__main__":
+    main()

--- a/lmdb/schema/196.sql
+++ b/lmdb/schema/196.sql
@@ -1,0 +1,35 @@
+-- #196: demote facet native_ids squatting on non-channel containers.
+--
+-- Pre-#190 rows (V3-migrated channel-URL containers) and tabs that self-pulled before their
+-- channel hold native_id = the channel's shared (facet) id without the attrs.kind='channel'
+-- merge guard. Post-#190, every sibling tab's self-pull proposes that same id via
+-- null_backfill; the clash merge then deletes the holder into the tab (tab-eats-tab cascade:
+-- distinct tabs serially merged, run histories mixed). The code fix (facet_native guard in
+-- _apply_backfill) stops the merges; this one-off moves the squatting ids into the soft
+-- attrs.channel_id hint so the rows match the post-#190 convention (containers URL-keyed,
+-- facet id as hint) and the analyzer's duplicate-pair backlog reflects reality.
+--
+-- Scope: a container, URL-keyed-able (url present — never demote a url-less row, the id is
+-- its only key), not a guarded channel, whose native_id is known to be a facet id: some thing
+-- of the same extractor carries it as an attrs.channel_id hint (the post-#190 fan-out stores
+-- the hint on every sibling tab). Extractor-scoped on purpose: matching on the bare value
+-- would also sweep e.g. twitchvideos containers, where the single per-channel container
+-- legitimately holds the uploader id (no tab siblings, no cascade).
+
+-- Preview first:
+-- SELECT id, extractor_key, url, native_id, attrs->>'channel_id' AS hint, try_on
+-- FROM thing t
+-- WHERE t.container AND t.native_id IS NOT NULL AND t.url IS NOT NULL
+--   AND coalesce(t.attrs->>'kind', '') <> 'channel'
+--   AND EXISTS (SELECT 1 FROM thing h
+--               WHERE h.attrs->>'channel_id' = t.native_id
+--                 AND h.extractor_key = t.extractor_key);
+
+UPDATE thing t SET
+    attrs = coalesce(t.attrs, '{}'::jsonb) || jsonb_build_object('channel_id', t.native_id),
+    native_id = NULL
+WHERE t.container AND t.native_id IS NOT NULL AND t.url IS NOT NULL
+  AND coalesce(t.attrs->>'kind', '') <> 'channel'
+  AND EXISTS (SELECT 1 FROM thing h
+              WHERE h.attrs->>'channel_id' = t.native_id
+                AND h.extractor_key = t.extractor_key);

--- a/lmdb/schema/196.sql
+++ b/lmdb/schema/196.sql
@@ -5,31 +5,54 @@
 -- merge guard. Post-#190, every sibling tab's self-pull proposes that same id via
 -- null_backfill; the clash merge then deletes the holder into the tab (tab-eats-tab cascade:
 -- distinct tabs serially merged, run histories mixed). The code fix (facet_native guard in
--- _apply_backfill) stops the merges; this one-off moves the squatting ids into the soft
--- attrs.channel_id hint so the rows match the post-#190 convention (containers URL-keyed,
--- facet id as hint) and the analyzer's duplicate-pair backlog reflects reality.
+-- _apply_backfill) stops the merges; this one-off frees the squatting ids (each kept as the
+-- soft attrs.channel_id hint) so the rows match the post-#190 convention (containers
+-- URL-keyed, facet id as hint), the id is claimable by the next self-owned pull (#160), and
+-- the analyzer's duplicate-pair backlog reflects reality.
 --
--- Scope: a container, URL-keyed-able (url present — never demote a url-less row, the id is
--- its only key), not a guarded channel, whose native_id is known to be a facet id: some thing
--- of the same extractor carries it as an attrs.channel_id hint (the post-#190 fan-out stores
--- the hint on every sibling tab). Extractor-scoped on purpose: matching on the bare value
--- would also sweep e.g. twitchvideos containers, where the single per-channel container
--- legitimately holds the uploader id (no tab siblings, no cascade).
+-- Evidence that an id is a facet (shared) id comes from run history: some OTHER container of
+-- the same (backend, extractor_key) has a run whose raw data_json reports the id as its own
+-- channel_id/uploader_id -- xform.owns_native_id's two-namespace test in SQL. Run-derived on
+-- purpose:
+--   * it works on deploy day: the attrs.channel_id hints an earlier draft matched are only
+--     written by the code fix shipping WITH this file (0 rows would match at deploy), and
+--     sibling-row evidence inside thing itself is impossible (the thing_native partial unique
+--     index forbids two rows sharing an id);
+--   * a row's own runs are never evidence against it (h.id <> t.id), so a channel that
+--     legitimately claimed a free facet id cannot demote itself;
+--   * h.container keeps leaf runs out: a video's data_json carries its uploader's id, which
+--     would otherwise falsely demote the single per-channel containers (twitchvideos,
+--     vkuservideos) that legitimately hold the uploader id (no tab siblings, no cascade);
+--   * r.success is NOT required -- a failed run's data_json is kept for debugging and its
+--     identity fields are still valid evidence; ->> on a non-object data_json (v3-migration
+--     synthetic payloads) is SQL NULL, never an error.
+--
+-- Idempotent / safe to re-run: a demoted row no longer matches native_id IS NOT NULL, and a
+-- post-fix free-claimer demoted by fresh sibling evidence simply re-claims the freed id on
+-- its next self-pull (claim-when-free, #160).
 
 -- Preview first:
--- SELECT id, extractor_key, url, native_id, attrs->>'channel_id' AS hint, try_on
+-- SELECT t.id, t.extractor_key, t.url, t.native_id, t.attrs->>'channel_id' AS hint, t.try_on
 -- FROM thing t
 -- WHERE t.container AND t.native_id IS NOT NULL AND t.url IS NOT NULL
 --   AND coalesce(t.attrs->>'kind', '') <> 'channel'
---   AND EXISTS (SELECT 1 FROM thing h
---               WHERE h.attrs->>'channel_id' = t.native_id
---                 AND h.extractor_key = t.extractor_key);
+--   AND EXISTS (SELECT 1 FROM run r JOIN thing h ON h.id = r.thing_id
+--               WHERE h.id <> t.id
+--                 AND h.container
+--                 AND h.backend = t.backend
+--                 AND h.extractor_key = t.extractor_key
+--                 AND (r.data_json->>'channel_id' = t.native_id
+--                      OR r.data_json->>'uploader_id' = t.native_id));
 
 UPDATE thing t SET
     attrs = coalesce(t.attrs, '{}'::jsonb) || jsonb_build_object('channel_id', t.native_id),
     native_id = NULL
 WHERE t.container AND t.native_id IS NOT NULL AND t.url IS NOT NULL
   AND coalesce(t.attrs->>'kind', '') <> 'channel'
-  AND EXISTS (SELECT 1 FROM thing h
-              WHERE h.attrs->>'channel_id' = t.native_id
-                AND h.extractor_key = t.extractor_key);
+  AND EXISTS (SELECT 1 FROM run r JOIN thing h ON h.id = r.thing_id
+              WHERE h.id <> t.id
+                AND h.container
+                AND h.backend = t.backend
+                AND h.extractor_key = t.extractor_key
+                AND (r.data_json->>'channel_id' = t.native_id
+                     OR r.data_json->>'uploader_id' = t.native_id));

--- a/lmdb/test_api.py
+++ b/lmdb/test_api.py
@@ -1087,6 +1087,23 @@ def test_meta_result_fans_out_url_less_channel(client):
     assert chan[0]["thing"]["attrs"]["source_extractor"] == "somesite"
 
 
+def test_meta_result_upgrades_plain_edge_to_channel(client):
+    # A full extract proves the parent is the video's uploader, so an existing plain membership
+    # edge for the pair (V3-migrated data, or a channel first pulled as an anonymous playlist)
+    # upgrades to channel=True — pre-fix the edge-PK conflict silently left it False.
+    chan = _seed_thing(type="channel", url="http://e/chanup", try_on=None)
+    v, rid = _claimed_meta(client, url="http://e/vup")
+    _seed_rel(chan, v)                     # pre-existing plain membership edge (channel=False)
+    client.post(f"/jobs/{rid}/result",
+                json={"success": True,
+                      "video": {"native_id": "vup", "title": "VUP", "extractor_key": "somesite",
+                                "channel": {"native_id": "UCup", "url": "http://e/chanup"},
+                                "info_json": {"id": "vup"}}})
+    related = client.get(f"/things/{v}/related").json()
+    edges = [e for e in related if e["thing"]["id"] == chan]
+    assert len(edges) == 1 and edges[0]["channel"] is True
+
+
 def test_ingest_propagates_hints(client):
     # 1.3b: a playlist's cookies/lpm_lib hints propagate onto its video stubs (attrs);
     # channels do not carry the hints (bucket only).

--- a/lmdb/test_api.py
+++ b/lmdb/test_api.py
@@ -1640,6 +1640,60 @@ def test_channel_tab_self_pull_preserves_channel(client):
     assert tab_thing["native_id"] is None                        # tab left URL-keyed (clash backfill dropped)
 
 
+def test_tab_self_pull_never_eats_unguarded_facet_holder(client):
+    # Tab-eats-tab cascade: the channel's shared id is held by a row WITHOUT the kind='channel'
+    # guard hint (a migrated V3 channel-URL container, or a sibling tab that claimed the id on an
+    # earlier self-pull). A tab self-pull proposes that facet id via null_backfill; pre-fix the
+    # clash merge-deleted the holder into the tab, which then held the id unguarded itself — so
+    # the next sibling's pull ate *it*, serially collapsing distinct tabs and mixing their run
+    # history. The facet clash must drop the claim instead: nothing is merged, every tab stays
+    # URL-keyed with the id as a soft channel_id hint.
+    holder = _seed_thing(container=True, url="http://yt/@casc/streams", try_on=None,
+                         extractor_key="youtubetab", native_id="UC")   # no attrs.kind guard
+    chan = models.UlChan(native_id="UC", title="Casc", url="http://yt/@casc")
+
+    def self_pull(tab_url, vid):
+        tid, rid = _claimed_run(client, tab_url)
+        pull = models.PullThing(
+            url=tab_url, native_id="UC", extractor_key="youtubetab", title="Casc tab",
+            container=True, playlist_count=1, channel=chan,
+            entries=[models.PullThing(native_id=vid, url=f"http://yt/v/{vid}", title=vid,
+                                      extractor_key="youtube", channel=chan)],
+        ).model_dump(mode="json")
+        assert client.post(f"/jobs/{rid}/result", json={"playlist": pull}).status_code == 200
+        return client.get(f"/things/{tid}").json()
+
+    tab_a = self_pull("http://yt/@casc/videos", "v1")
+    assert client.get(f"/things/{holder}").status_code == 200     # holder NOT merged/deleted
+    assert client.get(f"/things/{holder}").json()["native_id"] == "UC"   # ... and keeps the id
+    assert tab_a["native_id"] is None                             # tab stays URL-keyed
+    assert (tab_a["attrs"] or {}).get("channel_id") == "UC"       # id kept as a soft hint
+
+    tab_b = self_pull("http://yt/@casc/shorts", "v2")             # next sibling: no cascade
+    assert client.get(f"/things/{holder}").status_code == 200
+    assert client.get(f"/things/{tab_a['id']}").status_code == 200
+    assert tab_b["native_id"] is None
+
+
+def test_channel_self_pull_claims_free_facet_id(client):
+    # The counterpart: when nobody holds the channel's shared id, a self-owned pull still claims
+    # it (that's how a directly-pulled channel gains the native_id that ID-based video->channel
+    # linking (#160) and the url-less-stub convergence rely on), plus the channel_id hint.
+    url = "http://yt/@fresh/videos"
+    tid, rid = _claimed_run(client, url)
+    chan = models.UlChan(native_id="UCfresh", title="Fresh", url="http://yt/@fresh")
+    pull = models.PullThing(
+        url=url, native_id="UCfresh", extractor_key="youtubetab", title="Fresh - videos",
+        container=True, playlist_count=1, channel=chan,
+        entries=[models.PullThing(native_id="f1", url="http://yt/v/f1", title="F1",
+                                  extractor_key="youtube", channel=chan)],
+    ).model_dump(mode="json")
+    assert client.post(f"/jobs/{rid}/result", json={"playlist": pull}).status_code == 200
+    thing = client.get(f"/things/{tid}").json()
+    assert thing["native_id"] == "UCfresh"                        # free facet id claimed
+    assert (thing["attrs"] or {}).get("channel_id") == "UCfresh"  # hint stored alongside
+
+
 def test_tab_permafail_ack_survives_parent_refeed(client):
     # A user acks a parent-fed tab (PATCH try_on=null, §2.5). A later channel pull must keep
     # feeding the tab's content but never reschedule it to self-pull — pre-fix the re-fan

--- a/lmdb/test_api.py
+++ b/lmdb/test_api.py
@@ -1069,6 +1069,25 @@ def test_meta_result_fans_out_channel(client):
     assert chan[0]["thing"]["url"] == "http://e/chan9"
 
 
+def test_meta_result_self_uploader_url_no_self_loop(client):
+    # An extractor whose uploader_url equals the video's own webpage_url resolves the uploader
+    # stub to the video itself — the fan-out must skip it, not insert a (v, v, channel=True)
+    # self-loop, which would also satisfy 160_backfill's orphan anti-join and hide the video
+    # from that heal.
+    v, rid = _claimed_meta(client, url="http://e/selfchan")
+    r = client.post(f"/jobs/{rid}/result",
+                    json={"success": True,
+                          "video": {"native_id": "scv", "title": "Self",
+                                    "extractor_key": "youtube",
+                                    "channel": {"url": "http://e/selfchan"},
+                                    "info_json": {"id": "scv"}}})
+    assert r.status_code == 200
+    related = client.get(f"/things/{v}/related").json()
+    assert [e for e in related if e["channel"]] == []     # no self channel edge
+    t = client.get(f"/things/{v}").json()
+    assert t["container"] is False and t["last_success_dt"]   # enrichment itself unaffected
+
+
 def test_meta_result_fans_out_url_less_channel(client):
     # #160: a meta extract whose uploader has only an id (no URL) still links the video to a
     # native-id-keyed channel thing, with the video's extractor recorded as provenance.
@@ -1789,6 +1808,29 @@ def test_tab_self_pull_facet_guard_fires_on_real_id_shape(client):
     tab = client.get(f"/things/{tid}").json()
     assert tab["native_id"] is None                               # tab stays URL-keyed
     assert (tab["attrs"] or {}).get("channel_id") == "UCshape"    # id kept as a soft hint
+
+
+def test_channel_self_pull_url_fallback_facet_guard(client):
+    # The uploader can come with no ids at all — only a URL equal to the pull's own (a channel
+    # landing page). Self-ownership then rests on _same_identity's URL fallback, which the facet
+    # detection must share (it consumes ThingGraph.pull_is_channel): an id-only facet test
+    # misses this shape and merge-deletes the sibling holder exactly as pre-#213.
+    holder = _seed_thing(container=True, url="http://yt/@ufb/streams", try_on=None,
+                         extractor_key="youtubetab", native_id="UCufb")  # no kind guard
+    tid, rid = _claimed_run(client, "http://yt/@ufb")
+    chan = models.UlChan(url="http://yt/@ufb", title="UFB")      # no uploader/channel id
+    pull = models.PullThing(
+        url="http://yt/@ufb", native_id="UCufb", extractor_key="youtubetab", title="UFB",
+        container=True, playlist_count=1, channel=chan,
+        entries=[models.PullThing(native_id="uv", url="http://yt/v/uv", title="UV",
+                                  extractor_key="youtube", channel=models.UlChan())],
+    ).model_dump(mode="json")
+    assert client.post(f"/jobs/{rid}/result", json={"playlist": pull}).status_code == 200
+    assert client.get(f"/things/{holder}").status_code == 200     # holder NOT merged/deleted
+    assert client.get(f"/things/{holder}").json()["native_id"] == "UCufb"
+    thing = client.get(f"/things/{tid}").json()
+    assert thing["native_id"] is None                             # facet claim dropped
+    assert (thing["attrs"] or {}).get("channel_id") == "UCufb"    # id kept as a soft hint
 
 
 def test_tab_permafail_ack_survives_parent_refeed(client):

--- a/lmdb/test_api.py
+++ b/lmdb/test_api.py
@@ -425,6 +425,14 @@ def test_claim_meta_for_underdescribed_c(client):
     assert job and job["thing"]["id"] == v and job["download"] is False
 
 
+def test_claim_no_meta_for_already_rated(client):
+    # #217: a meta job exists to make a thing rateable, so a human-rated C leaf never needs
+    # one — skip it even while its stored metadata stays formally incomplete (last_success_dt
+    # NULL, e.g. a twitch VOD whose extractor never exposes a channel URL).
+    _seed_thing(type="video", url="http://e/vrated", human_rating=0.0, try_on=_TODAY)
+    assert _claim(client) is None
+
+
 def test_claim_download_outranks_meta(client):
     # A B video (download) outranks a C video (metadata-only) in a single ordering.
     b = _seed_thing(type="video", url="http://e/vb", human_rating=1.0, try_on=_TODAY)
@@ -997,6 +1005,53 @@ def test_ingest_channel_autopopulates_video_channel(client):
     assert vid["last_success_dt"]                         # metadata-complete -> no meta job
     related = client.get(f"/things/{vid['id']}/related").json()
     assert [e["thing"]["id"] for e in related if e["channel"]] == [tid]   # channel edge to chan
+
+
+def test_ingest_channel_autopopulates_via_channel_id(client):
+    # #217: the real youtube tab shape — the pull's own id is the raw channel_id (UC…) while
+    # UlChan.native_id carries the @handle-form uploader_id (different namespaces). Self-
+    # ownership must match on either id (xform.owns_native_id); the single-field compare left
+    # the #156 inheritance (and the #196 facet guard) silently dead on these pulls, so every
+    # tab-discovered video was born channel-less and earned a pointless Stage-2 meta job.
+    url = "http://yt/@real/videos"
+    tid, rid = _claimed_run(client, url)
+    chan = models.UlChan(native_id="@real", channel_id="UCreal", title="Real",
+                         url="http://yt/@real")
+    pl = models.PullThing(
+        url=url, native_id="UCreal", title="Real - Videos", extractor_key="youtubetab",
+        playlist_count=1, channel=chan,                 # own uploader, matched via channel_id
+        entries=[models.PullThing(native_id="rv", title="R Vid", url="http://yt/v/rv",
+                                  extractor_key="youtube", channel=models.UlChan())])
+    assert client.post(f"/jobs/{rid}/result",
+                       json={"playlist": pl.model_dump(mode="json")}).status_code == 200
+    vid = {v["native_id"]: v for v in
+           client.get("/things/", params={"container": False}).json()}["rv"]
+    assert vid["channel"] == "http://yt/@real"            # inherited the uploader URL
+    assert vid["last_success_dt"]                         # metadata-complete -> no meta job
+    related = client.get(f"/things/{vid['id']}/related").json()
+    assert [e["thing"]["id"] for e in related if e["channel"]] == [tid]   # channel edge to tab
+    tab = client.get(f"/things/{tid}").json()
+    assert tab["attrs"]["kind"] == "channel"              # self-owned pull tagged as channel
+
+
+def test_ingest_channel_autopopulates_uploader_id_with_other_channel_id(client):
+    # The other live shape: the pull's id equals uploader_id while a *different* channel_id is
+    # present. Both shapes coexist in recorded pulls, so the self-ownership test must accept a
+    # match on either id — a "prefer channel_id" flip would break this one.
+    url = "http://yt/@old/videos"
+    tid, rid = _claimed_run(client, url)
+    chan = models.UlChan(native_id="@old", channel_id="UCother", title="Old",
+                         url="http://yt/@old")
+    pl = models.PullThing(
+        url=url, native_id="@old", title="Old - Videos", extractor_key="youtubetab",
+        playlist_count=1, channel=chan,                  # own uploader, matched via native_id
+        entries=[models.PullThing(native_id="ov", title="O Vid", url="http://yt/v/ov",
+                                  extractor_key="youtube", channel=models.UlChan())])
+    assert client.post(f"/jobs/{rid}/result",
+                       json={"playlist": pl.model_dump(mode="json")}).status_code == 200
+    vid = {v["native_id"]: v for v in
+           client.get("/things/", params={"container": False}).json()}["ov"]
+    assert vid["channel"] == "http://yt/@old" and vid["last_success_dt"]
 
 
 def test_meta_result_fans_out_channel(client):
@@ -1692,6 +1747,31 @@ def test_channel_self_pull_claims_free_facet_id(client):
     thing = client.get(f"/things/{tid}").json()
     assert thing["native_id"] == "UCfresh"                        # free facet id claimed
     assert (thing["attrs"] or {}).get("channel_id") == "UCfresh"  # hint stored alongside
+
+
+def test_tab_self_pull_facet_guard_fires_on_real_id_shape(client):
+    # #217: the cascade tests above use UlChan.native_id == the pull id, but on a real youtube
+    # tab pull UlChan.native_id is the @handle-form uploader_id while the pull's own id is the
+    # raw channel_id — the live cascade pulls (#196) have exactly this shape. The facet
+    # detection must match on channel_id too, or the guard is dead code and the holder is
+    # merge-deleted just like pre-#213.
+    holder = _seed_thing(container=True, url="http://yt/@shape/streams", try_on=None,
+                         extractor_key="youtubetab", native_id="UCshape")  # no kind guard
+    chan = models.UlChan(native_id="@shape", channel_id="UCshape", title="Shape",
+                         url="http://yt/@shape")
+    tid, rid = _claimed_run(client, "http://yt/@shape/videos")
+    pull = models.PullThing(
+        url="http://yt/@shape/videos", native_id="UCshape", extractor_key="youtubetab",
+        title="Shape tab", container=True, playlist_count=1, channel=chan,
+        entries=[models.PullThing(native_id="sv", url="http://yt/v/sv", title="SV",
+                                  extractor_key="youtube", channel=models.UlChan())],
+    ).model_dump(mode="json")
+    assert client.post(f"/jobs/{rid}/result", json={"playlist": pull}).status_code == 200
+    assert client.get(f"/things/{holder}").status_code == 200     # holder NOT merged/deleted
+    assert client.get(f"/things/{holder}").json()["native_id"] == "UCshape"
+    tab = client.get(f"/things/{tid}").json()
+    assert tab["native_id"] is None                               # tab stays URL-keyed
+    assert (tab["attrs"] or {}).get("channel_id") == "UCshape"    # id kept as a soft hint
 
 
 def test_tab_permafail_ack_survives_parent_refeed(client):

--- a/lmdb/xform.py
+++ b/lmdb/xform.py
@@ -239,16 +239,29 @@ class ThingGraph(NamedTuple):
     rels: list[models.Rel]
 
 
+def owns_native_id(native_id: Optional[str], chan: models.UlChan) -> bool:
+    """Is `native_id` one of the uploader's ids (uploader_id OR channel_id)?
+
+    yt-dlp's uploader_id and channel_id are different namespaces (youtube: @handle vs UC…)
+    and a self-owned container's own id can match either — live pulls show both shapes — so
+    a single-field comparison silently misses one of them (#217; it also left the #196
+    facet guard dead on real pulls). The one self-ownership id test, shared by
+    `_same_identity` and the facet-pull detection in api._fanout.
+    """
+    return native_id is not None and native_id in (chan.native_id, chan.channel_id)
+
+
 def _same_identity(parent: models.Thing, chan: models.UlChan) -> bool:
     """Is `chan` (an entry's uploader/owner) the same node as the pulled `parent` container?
 
     The channel case: the parent IS the uploader, so the parent->child edge is the
     channel/uploader edge (`rel.channel=True`) and no separate uploader node is needed.
-    Matched by `native_id`; URL only when a native_id is absent
-    (channel landing-vs-/videos URLs differ — #46 — so native_id is the reliable signal).
+    Matched by id (`owns_native_id`); URL only when no id is present on either side
+    (channel landing-vs-/videos URLs differ — #46 — so ids are the reliable signal).
     """
-    if parent.native_id is not None and chan.native_id is not None:
-        return parent.native_id == chan.native_id
+    if parent.native_id is not None and (chan.native_id is not None
+                                         or chan.channel_id is not None):
+        return owns_native_id(parent.native_id, chan)
     if chan.url is not None:
         return parent.url == chan.url
     return False
@@ -332,7 +345,8 @@ def pl_full2things(pl: models.PullThing, *, bucket: str,
         # rate-able (enough_to_rate needs a channel URL) without a separate Stage-2 meta pull.
         vid_owner = vid.channel
         if (pull_is_channel and vid.container is False
-                and not vid.channel.url and not vid.channel.native_id):
+                and not vid.channel.url and not vid.channel.native_id
+                and not vid.channel.channel_id):
             vid_owner = pl.channel
             vid_thing.channel = pl_thing.channel or pl_thing.url
         # Every sub-container member is URL-keyed: null its native_id so `_find_thing` keys it by

--- a/lmdb/xform.py
+++ b/lmdb/xform.py
@@ -237,6 +237,7 @@ class ThingGraph(NamedTuple):
     members: list[models.Thing]  # member stubs: leaf videos (False/None) + sub-containers (True)
     channels: list[models.Thing]  # per-video uploader containers (kind='channel')
     rels: list[models.Rel]
+    pull_is_channel: bool       # the container IS its own uploader (`_same_identity`)
 
 
 def owns_native_id(native_id: Optional[str], chan: models.UlChan) -> bool:
@@ -245,8 +246,8 @@ def owns_native_id(native_id: Optional[str], chan: models.UlChan) -> bool:
     yt-dlp's uploader_id and channel_id are different namespaces (youtube: @handle vs UC…)
     and a self-owned container's own id can match either — live pulls show both shapes — so
     a single-field comparison silently misses one of them (#217; it also left the #196
-    facet guard dead on real pulls). The one self-ownership id test, shared by
-    `_same_identity` and the facet-pull detection in api._fanout.
+    facet guard dead on real pulls). The one self-ownership id test, used by
+    `_same_identity` (whose result api._fanout consumes as `ThingGraph.pull_is_channel`).
     """
     return native_id is not None and native_id in (chan.native_id, chan.channel_id)
 
@@ -386,7 +387,8 @@ def pl_full2things(pl: models.PullThing, *, bucket: str,
                 rels.append(models.Rel(parent=vid_chan.id, child=vid_thing.id, channel=True))
 
     return ThingGraph(playlist=pl_thing, members=members,
-                      channels=list(channels_by_key.values()), rels=rels)
+                      channels=list(channels_by_key.values()), rels=rels,
+                      pull_is_channel=pull_is_channel)
 
 
 def reconcile_count(pl: models.PullThing) -> int:


### PR DESCRIPTION
## Problem

Live-data analysis (stats/ dumps 2026-07-03..05, `compare/` tooling) showed the post-#190 merge convergence actively destroying data: a channel tab's self-pull backfills the shared/facet `native_id` (= channel_id), and when the current holder lacks the `attrs.kind='channel'` guard (migrated V3 channel-URL containers do), `_apply_backfill`'s clash merge deletes the holder into the tab. The new holder is itself unguarded, so the next sibling tab's pull eats *it* — a serial cascade. Observed live: `ad958344 → 310124b8 → b21a732b` ran twice in two days, deleting two distinct things of one channel and mixing three run histories; 14 unguarded holders remained, with the next cascade links scheduled from **2026-07-14**.

This is the destructive half of #196 (tab-added-first identity inversion), filed from the #190 review.

## Fix

- `_fanout` marks a self-owned pull's proposed `native_id` as `facet_native` (pull id == its own uploader's id) and stores the soft `attrs.channel_id` hint.
- `_apply_backfill(facet_native=True)` **drops the claim on clash instead of merging** — for a facet id, same id does not mean same thing; the holder is usually a sibling tab or URL-variant. A same-row *url* clash still converges as a true duplicate.
- Claiming a **free** facet id is unchanged: a directly-pulled channel still gains the id that #160 id-based linking and `_converge_urlless_channel` rely on. (A never-claim rule was considered and rejected: yt-dlp's `webpage_url` virtually never equals `channel_url`, so there is no reliable canonical-channel test, and never-claim would regress #160 for twitch/vk.)
- `schema/196.sql`: one-off cleanup demoting the ids already squatting on unguarded rows into `attrs.channel_id` hints. Extractor-scoped on purpose — matching on the bare value would also sweep ~21 `twitchvideos` containers that legitimately hold their uploader id (single container per channel, no tab siblings, no cascade). Validated against the sanitized live snapshot: matches exactly the 14 youtubetab relics.

## Verification

- New regression test replays the cascade (unguarded holder + two sibling tab self-pulls: nothing merged/deleted, tabs stay URL-keyed with the hint) plus a claim-when-free counterpart; full `lmdb/test_api.py` suite passes (123).
- `compare/run_compare.sh` differential replay of all 134 recorded live pulls, master vs this branch: 0 failures on both, graphs identical — no behavior change on any historical pull (the cascade pulls only fire from 07-14).

## Deploy

Deploy + apply `schema/196.sql` on the live host **before 2026-07-14** (preview SELECT included in the file). Post-deploy monitoring semantics for the compare tooling (facet-pair exclusion, `--since` go/no-go) are updated in the local-only `compare/` dir / `compare.tar`.

Fixes the destructive part of #196; the tab-floats-unlinked consequence there remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second commit: self-ownership must match either uploader id (#217)

Investigating #217 (worker grinding Stage-2 `meta` jobs on apparently metadata-complete C videos) landed on the same root cause as this PR — and revealed the facet guard above was **dead code on real pulls**:

- yt-dlp's `uploader_id` and `channel_id` are different namespaces (youtube: `@handle` vs `UC…`). `UlChan.native_id` collapses them (uploader_id-first), but a tab pull's own `id` is the raw channel_id. Recorded live pulls show **both** shapes: 232 youtubetab self-pulls match on channel_id, 80 on uploader_id (with a different channel_id present — so a priority flip would just break the other bucket).
- `xform._same_identity` therefore failed on the 232-shape → the #156 channel inheritance never fired → every tab-discovered video was born channel-less, failed `enough_to_rate`, and was dispatched a pointless full-extract meta job. Live: ~25.6k youtube meta-pending stubs, all missing *only* `channel`.
- `facet_pull` used the same single-field compare — and the recorded cascade pull (`b21a732b…`) has `id == channel_id ≠ uploader_id`, so **without this commit the guard never engages and the 07-14 cascade proceeds anyway**. (That's also why the earlier replay showed "graphs identical".)

Fix: `UlChan` carries `channel_id` alongside `native_id` (worker→API pull contract only, no DB change); one shared predicate `xform.owns_native_id` backs both `_same_identity` and `facet_pull`. Existing channel-less stubs heal organically — `channel` is a `null_backfill` field, so each channel's next re-pull fills it and the fan-out marks the stubs metadata-complete.

Also from #217: `claim_job`'s `meta_branch` now skips human-rated leaves (`human_rating IS NULL`) — a meta exists to make a thing rateable, so a rated one never needs it. (twitch/vk VOD-list pulls carry no uploader fields at all — extractor-layer gap, not fixable LM-side — and a twitch meta can't even fill `channel` (id-only uploader), so rated ones were pure waste.)

Re-verification with the commit: differential replay of the recorded live pulls now shows the guard **firing** — master merges the three cascade tabs (mixed run histories, e.g. 17 = two tabs' runs), the branch keeps them URL-keyed and separate; try_on deltas 0, no runs lost. Recorded self-owned tab pulls produce 15,702 leaf stubs born rateable (previously 0 on the channel_id-shape pulls). Full suite: 127 passed (4 new regression tests with the real id shapes).
